### PR TITLE
Add reconnection support.

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -1,11 +1,12 @@
 /*!
  * PostgreSQL connector for LoopBack
  */
-var postgresql = require('pg');
+var pg = require('pg.js');
 var SqlConnector = require('loopback-connector').SqlConnector;
 var util = require('util');
 var async = require('async');
 var debug = require('debug')('loopback:connector:postgresql');
+var reconnectCore = require('reconnect-core');
 
 /**
  *
@@ -17,7 +18,7 @@ var debug = require('debug')('loopback:connector:postgresql');
  * @header PostgreSQL.initialize(dataSource, [callback])
  */
 exports.initialize = function initializeDataSource(dataSource, callback) {
-  if (!postgresql) {
+  if (!pg) {
     return;
   }
 
@@ -26,7 +27,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   dbSettings.user = dbSettings.user || dbSettings.username;
   dbSettings.debug = dbSettings.debug || debug.enabled;
 
-  dataSource.connector = new PostgreSQL(postgresql, dbSettings);
+  dataSource.connector = new PostgreSQL(pg, dbSettings);
   dataSource.connector.dataSource = dataSource;
 
   if (callback) {
@@ -53,12 +54,12 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
  *
  * @constructor
  */
-function PostgreSQL(postgresql, settings) {
+function PostgreSQL(pg, settings) {
   // this.name = 'postgresql';
   // this._models = {};
   // this.settings = settings;
   this.constructor.super_.call(this, 'postgresql', settings);
-  this.postgresql = new postgresql.Client(settings.url || settings);
+  this.pg = pg;
   this.connection = null;
   this.settings = settings;
   if (settings.debug) {
@@ -89,26 +90,40 @@ PostgreSQL.prototype.connect = function (callback) {
     }
     return;
   }
+
   var url = this.settings.host.url || (this.settings.host + ':' + this.settings.port);
   if (this.settings.debug) {
     this.debug('Connecting to ' + url);
   }
-  this.postgresql.connect(function (err) {
-    if (!err) {
-      self.connection = self.postgresql;
-      if (self.settings.debug) {
-        self.debug('Connected to ' + url);
-      }
-      // console.log(self.connection);
-      callback && callback(err, self.connection);
-    } else {
-      if (callback) {
-        return callback(err);
-      }
-      console.error(err);
-      throw err;
-    }
+
+  var reconnect = reconnectCore(function(connStr) {
+    var client = new self.pg.Client(connStr);
+    client.connect();
+    return client;
   });
+
+  reconnect()
+  .on('connect', function(client) {
+    self.connection = client;
+    if (self.settings.debug) {
+      self.debug('Connected to ' + url);
+    }
+    callback && callback(null, client);
+  })
+  .on('reconnect', function(n, delay) {
+    if (self.settings.debug) {
+      self.debug('Reconnecting. Connection #%d, delay %d.', n, delay);
+    }
+  })
+  .on('disconnect', function(err) {
+    if (self.settings.debug) {
+      self.debug('Disconnected. Err: %s', err && err.message);
+    }
+    if (err) console.error(err);
+    self.connection = null;
+    // Don't throw here
+  })
+  .connect(this.settings.url || this.settings);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "test": "mocha -R spec --timeout 10000 --require test/init.js test/*.test.js"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "pg": "^4.1.0",
-    "debug": "^2.0.0",
-    "loopback-connector": "1.x"
+    "async": "~0.9.0",
+    "pg.js": "~4.1.0",
+    "debug": "~2.0.0",
+    "loopback-connector": "1.x",
+    "reconnect-core": "^0.1.0"
   },
   "devDependencies": {
     "loopback-datasource-juggler": "1.x.x",


### PR DESCRIPTION
Renamed a few vars to make a bigger distinction between
postgresql (the connector), pg (the connection library), and the
individual connection.

Thinking this might make more sense in `loopback-datasource-juggler`. If it were moved there, this library would still require a small rework so that `connect()` instantiates a new `pg.Client` (as they cannot be reused).
