### PR TITLE
Create table if not exists

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -1318,7 +1318,7 @@ PostgreSQL.prototype.createTable = function (model, cb) {
   var self = this;
   var name = self.tableEscaped(model);
 
-  self.query('CREATE TABLE ' + name + ' (\n  ' + self.propertiesSQL(model) + '\n)', cb);
+  self.query('CREATE TABLE IF NOT EXISTS ' + name + ' (\n  ' + self.propertiesSQL(model) + '\n)', cb);
 };
 
 /**


### PR DESCRIPTION
Previously, declaring a model to explicitly use a specific table name would fail, if there were multiple models that refer to the same table. Even though the table should have been dropped by automigrate before, this was not without issues, yielding a postgresql error like: `relation "my_table" already exists`.