### PR TITLE
[Issue #50] Removes keys with undefined values.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ lib-cov
 *.out
 *.pid
 *.gz
-
+.lvimrc
 pids
 logs
 results

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -382,6 +382,15 @@ PostgreSQL.prototype.update =
  */
 PostgreSQL.prototype.toFields = function (model, data, forCreate) {
   var self = this;
+
+  // There is no undefined in PostgreSQL and sending NULL for every
+  // undefined field prevents the database from handling default values.
+  //
+  // If you actually want to send NULL values, use NULL values.
+  Object.keys(data).forEach(function (k) {
+    if (data[k] === undefined) delete data[k];
+  });
+
   var props = self._categorizeProperties(model, data);
   var dataIdNames = props.idsInData;
   var nonIdsInData = props.nonIdsInData;

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -256,7 +256,7 @@ PostgreSQL.prototype._categorizeProperties = function(model, data) {
  */
 PostgreSQL.prototype.create = function (model, data, callback) {
   var self = this;
-	data = self.filterUndefined(data);
+  data = self.filterUndefined(data);
   var props = self._categorizeProperties(model, data);
 
   var sql = [];
@@ -295,7 +295,7 @@ PostgreSQL.prototype.create = function (model, data, callback) {
 /*
 PostgreSQL.prototype.updateOrCreate = function (model, data, callback) {
   var self = this;
-	data = self.filterUndefined(data);
+  data = self.filterUndefined(data);
   var props = self._categorizeProperties(model, data);
   var idColumns = props.ids.map(function(key) {
     return self.columnEscaped(model, key); }
@@ -344,7 +344,7 @@ PostgreSQL.prototype.updateOrCreate = function (model, data, callback) {
  */
 PostgreSQL.prototype.save = function (model, data, callback) {
   var self = this;
-	data = self.filterUndefined(data);
+  data = self.filterUndefined(data);
   var props = self._categorizeProperties(model, data);
 
   var sql = [];
@@ -363,7 +363,7 @@ PostgreSQL.prototype.save = function (model, data, callback) {
 PostgreSQL.prototype.update =
   PostgreSQL.prototype.updateAll = function (model, where, data, callback) {
     var whereClause = this.buildWhere(model, where);
-		data = this.filterUndefined(data);
+    data = this.filterUndefined(data);
 
     var sql = ['UPDATE ', this.tableEscaped(model), ' SET ',
       this.toFields(model, data), ' ', whereClause].join('');
@@ -392,7 +392,7 @@ PostgreSQL.prototype.filterUndefined = function (data) {
     if (data[k] === undefined) delete data[k];
   });
 
-	return data;
+  return data;
 }
 
 /*!

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -256,6 +256,7 @@ PostgreSQL.prototype._categorizeProperties = function(model, data) {
  */
 PostgreSQL.prototype.create = function (model, data, callback) {
   var self = this;
+	data = self.filterUndefined(data);
   var props = self._categorizeProperties(model, data);
 
   var sql = [];
@@ -294,6 +295,7 @@ PostgreSQL.prototype.create = function (model, data, callback) {
 /*
 PostgreSQL.prototype.updateOrCreate = function (model, data, callback) {
   var self = this;
+	data = self.filterUndefined(data);
   var props = self._categorizeProperties(model, data);
   var idColumns = props.ids.map(function(key) {
     return self.columnEscaped(model, key); }
@@ -342,6 +344,7 @@ PostgreSQL.prototype.updateOrCreate = function (model, data, callback) {
  */
 PostgreSQL.prototype.save = function (model, data, callback) {
   var self = this;
+	data = self.filterUndefined(data);
   var props = self._categorizeProperties(model, data);
 
   var sql = [];
@@ -360,6 +363,7 @@ PostgreSQL.prototype.save = function (model, data, callback) {
 PostgreSQL.prototype.update =
   PostgreSQL.prototype.updateAll = function (model, where, data, callback) {
     var whereClause = this.buildWhere(model, where);
+		data = this.filterUndefined(data);
 
     var sql = ['UPDATE ', this.tableEscaped(model), ' SET ',
       this.toFields(model, data), ' ', whereClause].join('');
@@ -374,6 +378,24 @@ PostgreSQL.prototype.update =
   };
 
 /*!
+ * Filters undefined values from model instance data
+ *
+ * @param {Object} The model instance data
+ */
+
+PostgreSQL.prototype.filterUndefined = function (data) {
+  // There is no undefined in PostgreSQL and sending NULL for every
+  // undefined field prevents the database from handling default values.
+  //
+  // If you actually want to send NULL values, use NULL values.
+  Object.keys(data).forEach(function (k) {
+    if (data[k] === undefined) delete data[k];
+  });
+
+	return data;
+}
+
+/*!
  * Build a list of column name/value pairs
  *
  * @param {String} The model name
@@ -382,14 +404,6 @@ PostgreSQL.prototype.update =
  */
 PostgreSQL.prototype.toFields = function (model, data, forCreate) {
   var self = this;
-
-  // There is no undefined in PostgreSQL and sending NULL for every
-  // undefined field prevents the database from handling default values.
-  //
-  // If you actually want to send NULL values, use NULL values.
-  Object.keys(data).forEach(function (k) {
-    if (data[k] === undefined) delete data[k];
-  });
 
   var props = self._categorizeProperties(model, data);
   var dataIdNames = props.idsInData;


### PR DESCRIPTION
Removes keys with undefined values from data before creating SQL query.
This prevents sending NULL values to Postgres for undefined values,
which prevents the Postgres from handling default values.

(Postgre)SQL does support undefined values. If you want to use NULL
values you should define them as such.