### PR TITLE
autocreate schema if it does not exist during migration/update

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -1303,6 +1303,7 @@ PostgreSQL.prototype.createTable = function (model, cb) {
   var self = this;
   var name = self.tableEscaped(model);
 
+  self.query('CREATE SCHEMA IF NOT EXISTS ' + self.schemaName(model));
   self.query('CREATE TABLE ' + name + ' (\n  ' + self.propertiesSQL(model) + '\n)', cb);
 };
 

--- a/test/postgresql.autocreateschema.test.js
+++ b/test/postgresql.autocreateschema.test.js
@@ -1,0 +1,49 @@
+var should = require('should'),
+    assert = require('assert');
+var Another, Post, db;
+
+describe('Autocreate schema if not exists', function () {
+    before(function () {
+        db = getDataSource();
+
+        Post = db.define('PostInCustomSchema', {
+            created: {
+                type: 'Date'
+            }
+        }, {
+            postgresql: {
+                schema: 'myschema'
+            }
+        });
+
+        Another = db.define('PostInDefaultSchema', {
+            created: {
+                type: 'Date'
+            }
+        });
+    });
+
+    it('should run migration for custom schema objects', function (done) {
+        db.automigrate('PostInCustomSchema', function (err) {
+            should.not.exist(err);
+            done();
+        });
+    });
+
+    it('should run migration for default schema objects', function (done) {
+        db.automigrate('PostInDefaultSchema', function (err) {
+            should.not.exist(err);
+            done();
+        });
+    });
+
+    it('should have new schema in place', function (done) {
+        var query = "select table_schema, column_name, data_type, character_maximum_length, column_default " +
+            "from information_schema.columns where table_name = 'postincustomschema' and column_name='created'";
+
+        db.connector.query(query, function (err, results) {
+            assert.equal(results[0].table_schema, "myschema");
+            done(err);
+        });
+    });
+})


### PR DESCRIPTION
Hi!

My models span across several schemas in Postgresql and I've found it handy if schemas are created automatically too during migration process.