### PR TITLE
provide database column default values via Loopback model description

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -1273,6 +1273,8 @@ PostgreSQL.prototype.propertySettingsSQL = function (model, propName) {
   }
   var result = self.columnDataType(model, propName);
   if (!propertyCanBeNull.call(self, model, propName)) result = result + ' NOT NULL';
+
+  result += self.columnDbDefault(model, propName);
   return result;
 };
 
@@ -1382,6 +1384,20 @@ function escape(val) {
   });
   // return "q'#"+val+"#'";
   return "'" + val + "'";
+}
+
+/*!
+ * Get the database-default value for column from given model property
+ *
+ * @param {String} model The model name
+ * @param {String} property The property name
+ * @returns {String} The column default value
+ */
+PostgreSQL.prototype.columnDbDefault = function(model, property) {
+  var columnMetadata = this.columnMetadata(model, property);
+  var colDefault = columnMetadata && columnMetadata.dbDefault;
+
+  return colDefault ? (' DEFAULT ' + columnMetadata.dbDefault): '';
 }
 
 /*!

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -236,7 +236,7 @@ PostgreSQL.prototype._categorizeProperties = function(model, data) {
   });
   var props = Object.keys(this._models[model].properties);
   var nonIdsInData = Object.keys(data).filter(function(key) {
-    return props.indexOf(key) !== -1 && ids.indexOf(key) === -1;
+    return props.indexOf(key) !== -1 && ids.indexOf(key) === -1 && data[key] !== undefined;
   });
   return {
     ids: ids,
@@ -387,6 +387,9 @@ PostgreSQL.prototype.toFields = function (model, data, forCreate) {
   var nonIdsInData = props.nonIdsInData;
   var query = [];
   if (forCreate) {
+      if(nonIdsInData.length == 0 && dataIdNames.length == 0) {
+          return 'default values';
+      }
     query.push('(');
     query.push(nonIdsInData.map(function (key) {
       return self.columnEscaped(model, key);

--- a/test/postgresql.dbdefaults.test.js
+++ b/test/postgresql.dbdefaults.test.js
@@ -1,0 +1,83 @@
+var should = require('should'),
+    assert = require('assert');
+var InvalidDefault, Post, db;
+
+describe('database default field values', function () {
+    before(function () {
+        db = getDataSource();
+
+        Post = db.define('PostWithDbDefaultValue', {
+            created: {
+                type: 'Date',
+                postgresql: {
+                    dbDefault: "now()"
+                }
+            },
+            defaultInt: {
+                type: 'Number',
+                postgresql: {
+                    dbDefault: "5"
+                }
+            },
+            oneMore: {
+                type: 'Number'
+            }
+        });
+
+        InvalidDefault = db.define('PostWithInvalidDbDefaultValue', {
+            created: {
+                type: 'Date',
+                postgresql: {
+                    dbDefault: "'5'"
+                }
+            }
+        });
+    });
+
+    it('should run migration', function (done) {
+        db.automigrate('PostWithDbDefaultValue', function () {
+            done();
+        });
+    });
+
+    it('should report inconsistent default values used', function (done) {
+        db.automigrate('PostWithInvalidDbDefaultValue', function (err) {
+            should.exists(err);
+            done();
+        });
+    });
+
+    it('should have \'now()\' default value in SQL column definition', function (done) {
+        var query = "select column_name, data_type, character_maximum_length, column_default " +
+            "from information_schema.columns where table_name = 'postwithdbdefaultvalue' and column_name='created'";
+
+        db.connector.query(query, function (err, results) {
+            assert.equal(results[0].column_default, "now()");
+            done(err);
+        });
+    });
+
+    it('should create a record with default value', function (done) {
+        Post.create({oneMore: 3}, function (err, p) {
+            should.not.exists(err);
+            Post.findOne({where: {defaultInt: 5}}, function (err, p) {
+                should.not.exists(err);
+                should.exists(p);
+                p.should.have.property('defaultInt', 5);
+                done();
+            });
+        });
+    });
+
+    it('should create a record with custom value', function (done) {
+        Post.create({oneMore: 2, defaultInt: 6}, function (err, p) {
+            should.not.exists(err);
+            Post.findOne({where: {defaultInt: 6}}, function (err, p) {
+                should.not.exists(err);
+                should.exists(p);
+                p.should.have.property('defaultInt', 6);
+                done();
+            });
+        });
+    });
+})


### PR DESCRIPTION
This PR allows to define the default value for a field by the means of database server. It is especially useful when the default value is calculated by a stored procedure.

Example usage is as follows:
simpleUsage.json
```
{
    "name": "simpleModel",
    "properties": {
        "creationDate": {
            "type": "Date",
            "postgresql": {
                "dbDefault": "now()"
            }
        }
    }
}
```
Another, a more complex usecase:
myModel.json
```
{
    "name": "myModel",
    "base": "PersistedModel",
    "options": {
        "idInjection": false,
        "postgresql": {
            "schema": "store",
            "table": "item"
        }
    },
    "properties": {
        "id": {
            "type": "String",
            "id": true,
            "postgresql": {
                "dataType": "uuid",
                "dbDefault": "uuid_generate_v4()"
            }
        }
    }
}
```

I quite agree that in many cases the same behaviour can be achieved by Loopback hooks, but still there are cases exist where default value is calculated by custom stored procedure on the DB side.

Feel free to contact me if you need more comments on this PR.