### PR TITLE
Create model foreign key matching type of opposite part of relation ...

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -1264,6 +1264,23 @@ function applySqlChanges(model, pendingChanges, cb) {
 }
 
 /*!
+ * Define foreign key matching to foreign model key type
+ */
+PostgreSQL.prototype.defineForeignKey = function (className, key, foreignClassName, cb) {
+  var foreignMeta = this.columnMetadata(foreignClassName, key);
+  if(foreignMeta && foreignMeta.dataType) {
+    this.defineProperty(className, key, {
+      type: this.columnDataType(foreignClassName, key),
+      postgresql: {
+        dataType: foreignMeta.dataType
+      }
+    });
+  } else {
+    cb(null, this.columnDataType(foreignClassName, key));
+  }
+}
+
+/*!
  * Build a list of columns for the given model
  * @param {String} model The model name
  * @returns {String}


### PR DESCRIPTION
(even if it has a custom field type)

Hi, I've stumbled upon something recently while defining relations between my models. Here they go:
Item:
```
{
    "name": "item",
    "base": "PersistedModel",
    "options": {
        "idInjection": false,
        "postgresql": {
            "schema": "store",
            "table": "item"
        }
    },
    "properties": {
        "item_id": {
            "type": "String",
            "id": true,
            "postgresql": {
                "dataType": "uuid",
                "dbDefault": "uuid_generate_v4()"
            }
        },
        "name": {
            "type": "String"
        }
    },
    "validations": [],
    "relations": {},
    "acls": [],
    "methods": []
}
```

Variant:
```
{
    "name": "variant",
    "base": "PersistedModel",
    "options": {
        "idInjection": false,
        "postgresql": {
            "schema": "store",
            "table": "item_variants"
        }
    },
    "properties": {
        "variant_id": {
            "type": "String",
            "id": true,
            "postgresql": {
                "dataType": "uuid",
                "dbDefault": "uuid_generate_v4()"
            }
        },
        "name": {
            "type": "String"
        }
    },
    "validations": [],
    "relations": {
        "item": {
            "type": "belongsTo",
            "model": "item",
            "foreignKey": "item_id"
        }
    },
    "acls": [],
    "methods": []
}
```
Without fix attached ```item_variants``` is as follows:
```
CREATE TABLE store.item_variants
(
  variant_id uuid NOT NULL DEFAULT uuid_generate_v4(),
  name character varying(1024),
  item_id character varying(1024),
  CONSTRAINT item_variants_pkey PRIMARY KEY (variant_id)
)
```
It is logically right, as I have item.item_id defined as String, but it has custom definition for postgresql database which is not honoured during foreign key creation.
Having this fix applied, ```item_variants``` has the following structure:
```
CREATE TABLE store.item_variants
(
  variant_id uuid NOT NULL DEFAULT uuid_generate_v4(),
  name character varying(1024),
  item_id uuid,
  CONSTRAINT item_variants_pkey PRIMARY KEY (variant_id)
)
```
which is perfectly correct!

Not sure, if it should be handled in loopback-datasource-juggler to act similarly for all connectors, so I've introduced it in postgresql connector for further discussion and review.