### PR TITLE
Fixes #92 - Allow case insensitive like and not like statements.

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -375,6 +375,16 @@ PostgreSQL.prototype.buildExpression =
           sql: columnName + " NOT LIKE ? ESCAPE '\\'",
           params: [columnValue]
         });
+      case 'ilike':
+        return new ParameterizedSQL({
+          sql: columnName + " ILIKE ? ESCAPE '\\'",
+          params: [columnValue]
+        });
+      case 'nilike':
+        return new ParameterizedSQL({
+          sql: columnName + " NOT ILIKE ? ESCAPE '\\'",
+          params: [columnValue]
+        });
       default:
         // Invoke the base implementation of `buildExpression`
         var exp = this.invokeSuper('buildExpression',


### PR DESCRIPTION
This adds "ilike" and "nilike" so we can do case insensitive searches with Postgres. Fixes #92 
