### PR TITLE
include the length of the column if its a char type. change character…

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -14,14 +14,14 @@ function mixinMigration(PostgreSQL) {
       }
       if (!err) {
         data.forEach(function(field) {
-          field.type = mapPostgreSQLDatatypes(field.type);
+          field.type = mapPostgreSQLDatatypes(field.type, field.length);
         });
       }
       cb(err, data);
     }
 
     this.execute('SELECT column_name AS "column", data_type AS "type", ' +
-      'is_nullable AS "nullable"' // , data_default AS "Default"'
+      'is_nullable AS "nullable", character_maximum_length as "length"' // , data_default AS "Default"'
       + ' FROM "information_schema"."columns" WHERE table_name=\'' +
       this.table(model) + '\'', decoratedCallback);
 
@@ -553,8 +553,12 @@ function mixinMigration(PostgreSQL) {
     }
   }
 
-  function mapPostgreSQLDatatypes(typeName) {
-    return typeName;
+  function mapPostgreSQLDatatypes(typeName, typeLength) {
+    if (typeName.toUpperCase() === 'CHARACTER VARYING' || typeName.toUpperCase() === 'VARCHAR') {
+      return typeLength ? 'VARCHAR('+typeLength+')' : 'VARCHAR(1024)';
+    } else {
+      return typeName;
+    }
   }
 
   PostgreSQL.prototype.propertyHasNotBeenDeleted = function(model, propName) {


### PR DESCRIPTION
… varying to varchar to match columnDataType method

`columnDataType` method for type of `string` returns `VARCHAR(<colLength>)`.  This never matches the `oldSettings.type` result in `datatypeChanged` function for two reasons:
1) `oldSettings.type` doesn't return the length of the column.
2) `oldSettings.type` could possibly be `CHARACTER VARYING`, which clearly doesn't === `VARCHAR`.

This commit fixes the problem and addresses this issue:
https://github.com/strongloop/loopback-connector-postgresql/issues/94