### PR TITLE
relnamespace in autoupdate

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -61,6 +61,8 @@ function mixinMigration(PostgreSQL) {
       'FROM pg_class t, pg_class i, pg_index ix, pg_am am ' +
       'WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND ' +
       'i.relam = am.oid AND ' +
+      'i.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = \''+
+      (this.schema(model) || 'public') + '\' ) AND ' +
       't.relkind=\'r\' AND t.relname=\'' +
       this.table(model) + '\'', decoratedIndexDataCallback);
   }


### PR DESCRIPTION
When multiple schemata exist in the database, autoupdate might try to drop indexes of foreign schemata. Fix: getTableStatus should check relnamespace
