### PR TITLE
- Adds support for long JSON strings when using `embedOne`

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -526,10 +526,10 @@ function mixinMigration(PostgreSQL) {
     switch (prop.type.name) {
       default:
       case 'String':
-      case 'Text':
-        return 'VARCHAR' + (colLength ? '(' + colLength + ')' : '(1024)');
       case 'JSON':
         return 'TEXT';
+      case 'Text':
+        return 'VARCHAR' + (colLength ? '(' + colLength + ')' : '(1024)');
       case 'Number':
         return 'INTEGER';
       case 'Date':

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -526,10 +526,10 @@ function mixinMigration(PostgreSQL) {
     switch (prop.type.name) {
       default:
       case 'String':
-      case 'JSON':
-        return 'TEXT';
       case 'Text':
         return 'VARCHAR' + (colLength ? '(' + colLength + ')' : '(1024)');
+      case 'JSON':
+        return 'TEXT';
       case 'Number':
         return 'INTEGER';
       case 'Date':

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -527,7 +527,7 @@ function mixinMigration(PostgreSQL) {
       default:
       case 'String':
       case 'JSON':
-        return 'VARCHAR' + (colLength ? '(' + colLength + ')' : '(1024)');
+        return 'TEXT';
       case 'Text':
         return 'VARCHAR' + (colLength ? '(' + colLength + ')' : '(1024)');
       case 'Number':


### PR DESCRIPTION
Without this change, we are unable to use postgresql as a datasource for some model relations that use the `embedsOne`. This is because the previous default value for detected JSON data types is `VARCHAR(1024)`. Now by default, the column data type will be `text`, allowing for long JSON strings to be imported into the database.

References issue:  https://github.com/strongloop/loopback-connector-postgresql/issues/131