### PR TITLE
Upgrade to pg 6.0.0

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -69,7 +69,7 @@ function PostgreSQL(postgresql, settings) {
   // this.settings = settings;
   this.constructor.super_.call(this, 'postgresql', settings);
   this.clientConfig = settings.url || settings;
-  this.pg = postgresql;
+  this.pg = new postgresql.Pool(this.clientConfig);
   this.settings = settings;
   if (settings.debug) {
     debug('Settings %j', settings);
@@ -95,7 +95,7 @@ PostgreSQL.prototype.getDefaultSchemaName = function() {
  */
 PostgreSQL.prototype.connect = function(callback) {
   var self = this;
-  self.pg.connect(self.clientConfig, function(err, client, done) {
+  self.pg.connect(function(err, client, done) {
     self.client = client;
     process.nextTick(done);
     callback && callback(err, client);
@@ -130,9 +130,12 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
         self.debug(err);
       }
       if (self.settings.debug && data) self.debug("%j", data);
-      process.nextTick(function() {
-        done(err);
-      });
+      if (done) {
+        process.nextTick(function() {
+          // Release the connection in next tick
+          done(err);
+        });
+      }
       var result = null;
       if (data) {
         switch (data.command) {
@@ -152,10 +155,10 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   if (transaction && transaction.connection &&
     transaction.connector === this) {
     debug('Execute SQL within a transaction');
-    executeWithConnection(transaction.connection,
-      transaction.connection.release);
+    // Do not release the connection
+    executeWithConnection(transaction.connection, null);
   } else {
-    self.pg.connect(self.clientConfig, function(err, connection, done) {
+    self.pg.connect(function(err, connection, done) {
       if (err) return callback(err);
       executeWithConnection(connection, done);
     });

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -19,12 +19,11 @@ function mixinTransaction(PostgreSQL) {
    */
   PostgreSQL.prototype.beginTransaction = function(isolationLevel, cb) {
     debug('Begin a transaction with isolation level: %s', isolationLevel);
-    this.pg.connect(this.clientConfig, function(err, connection, done) {
+    this.pg.connect(function(err, connection, done) {
       if (err) return cb(err);
       connection.query('BEGIN TRANSACTION ISOLATION LEVEL ' + isolationLevel,
         function(err) {
           if (err) return cb(err);
-          connection.release = done;
           cb(null, connection);
         });
     });

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "pg": "^4.2.0",
     "debug": "^2.1.1",
-    "loopback-connector": "^2.1.0"
+    "loopback-connector": "^2.1.0",
+    "pg": "^6.0.0"
   },
   "devDependencies": {
     "bluebird": "^2.9.12",


### PR DESCRIPTION
This PR upgrades the connector to use pg@6.x. It also fixes an issue for transaction connection releasing.