### PR TITLE
Fix #109 bug transaction concurrency.

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -71,7 +71,7 @@ function mixinTransaction(PostgreSQL) {
       if (err) {
         pool.destroy(connection);
       } else {
-        pool.release(connection);
+        pool.pool.release(connection);
       }
     }
   };


### PR DESCRIPTION
When running more than 9 transactions at the same time, we get an error: "pool.release is not a function". at line 74 in lib/transaction.js.
I found out that this.pg is returning an EvenEmitter, containing a pool which contains the function release.
Finally, when I call `pool.pool.release` instead of `pool.release`, everything works fine and the connections are released on my pg database.
This modification fixes the issue #109.
