### PR TITLE
Fixes #123: Sets default value for added columns when doing an autoupdate.

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -218,7 +218,13 @@ function mixinMigration(PostgreSQL) {
       var found = self.searchForPropertyInActual(
         model, self.column(model, propName), actualFields);
       if (!found && self.propertyHasNotBeenDeleted(model, propName)) {
-        sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));
+        // Set the default value for the column if one is defined in the model properties
+        if (m.properties[propName].default !== undefined) {
+          sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName) + ' DEFAULT ' + m.properties[propName].default);
+        }
+        else {
+          sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));
+        }
       }
     });
     if (sql.length > 0) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -218,13 +218,7 @@ function mixinMigration(PostgreSQL) {
       var found = self.searchForPropertyInActual(
         model, self.column(model, propName), actualFields);
       if (!found && self.propertyHasNotBeenDeleted(model, propName)) {
-        // Set the default value for the column if one is defined in the model properties
-        if (m.properties[propName].default !== undefined) {
-          sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName) + ' DEFAULT ' + m.properties[propName].default);
-        }
-        else {
-          sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));
-        }
+        sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));
       }
     });
     if (sql.length > 0) {
@@ -238,7 +232,8 @@ function mixinMigration(PostgreSQL) {
     var prop = this.getModelDefinition(model).properties[propName];
     var sqlCommand = self.columnEscaped(model, propName)
       + ' ' + self.columnDataType(model, propName) +
-      (self.isNullable(prop) ? "" : " NOT NULL");
+      (self.isNullable(prop) ? "" : " NOT NULL") 
+      + (prop.default === undefined) ? "" : (" DEFAULT " + prop.default);
     return sqlCommand;
   }
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -232,8 +232,8 @@ function mixinMigration(PostgreSQL) {
     var prop = this.getModelDefinition(model).properties[propName];
     var sqlCommand = self.columnEscaped(model, propName)
       + ' ' + self.columnDataType(model, propName) +
-      (self.isNullable(prop) ? "" : " NOT NULL") 
-      + (prop.default === undefined) ? "" : (" DEFAULT " + prop.default);
+      (self.isNullable(prop) ? "" : " NOT NULL") +
+      ((prop.default === undefined) ? "" : (" DEFAULT " + this.escapeValue(prop.default)));
     return sqlCommand;
   }
 


### PR DESCRIPTION
If a model property has a default value, set that as the database column's default value when adding the column in an auto update.

Patch modifies the SQL generated for adding a new column. If the loopback model has a default value, it uses this in the ADD COLUMN statement.

This ensures that existing database rows will have a value for the new column, and prevents the autoupdate failing due to null values.

Fixes #123