### PR TITLE
Add ILIKE functionality

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -386,8 +386,14 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
     case 'like':
       return new ParameterizedSQL(columnName + " LIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
+    case 'ilike':
+      return new ParameterizedSQL(columnName + " ILIKE ? ESCAPE '\\'",
+          [operatorValue]);
     case 'nlike':
       return new ParameterizedSQL(columnName + " NOT LIKE ? ESCAPE E'\\\\'",
+          [operatorValue]);
+    case 'nilike':
+      return new ParameterizedSQL(columnName + " NOT ILIKE ? ESCAPE '\\'",
           [operatorValue]);
     case 'regexp':
       if (operatorValue.global)

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -247,98 +247,88 @@ describe('postgresql connector', function() {
       Post.destroyAll(done);
     });
 
-    it('should support case sensitive queries using like',
-      function(done) {
-        Post.find({where: {content: {like: '%TestCase%'}}},
-          function(err, posts) {
-            should.not.exists(err);
-            posts.length.should.equal(1);
-            posts[0].content.should.equal('T1_TestCase');
-            done();
-          });
+    it('supports case sensitive queries using like', function(done) {
+      Post.find({where: {content: {like: '%TestCase%'}}}, function(err, posts) {
+        if (err) return done(err);
+        posts.length.should.equal(1);
+        posts[0].content.should.equal('T1_TestCase');
+        done();
       });
-
-    it('should not support case insensitive queries using like',
-      function(done) {
-        Post.find({where: {content: {like: '%tesTcasE%'}}},
-          function(err, posts) {
-            should.not.exists(err);
-            posts.length.should.equal(0);
-            done();
-          });
-      });
-
-    it('should support like for no match', function(done) {
-      Post.find({where: {content: {like: '%TestXase%'}}},
-        function(err, posts) {
-          should.not.exists(err);
-          posts.length.should.equal(0);
-          done();
-        });
     });
 
-    it('should support negative case sensitive queries using nlike',
-      function(done) {
-        Post.find({where: {content: {nlike: '%Case%'}}},
-          function(err, posts) {
-            should.not.exists(err);
-            posts.length.should.equal(0);
-            done();
-          });
+    it('rejects case insensitive queries using like', function(done) {
+      Post.find({where: {content: {like: '%tesTcasE%'}}}, function(err, posts) {
+        if (err) return done(err);
+        posts.length.should.equal(0);
+        done();
       });
+    });
 
-    it('should not support negative case insensitive queries using nlike',
-      function(done) {
-        Post.find({where: {content: {nlike: '%casE%'}}},
-          function(err, posts) {
-            should.not.exists(err);
-            posts.length.should.equal(2);
-            done();
-          });
+    it('supports like for no match', function(done) {
+      Post.find({where: {content: {like: '%TestXase%'}}}, function(err, posts) {
+        if (err) return done(err);
+        posts.length.should.equal(0);
+        done();
       });
+    });
 
-    it('should support nlike for no match', function(done) {
+    it('supports negative case sensitive queries using nlike', function(done) {
+      Post.find({where: {content: {nlike: '%Case%'}}}, function(err, posts) {
+        if (err) return done(err);
+        posts.length.should.equal(0);
+        done();
+      });
+    });
+
+    it('rejects negative case insensitive queries using nlike', function(done) {
+      Post.find({where: {content: {nlike: '%casE%'}}}, function(err, posts) {
+        if (err) return done(err);
+        posts.length.should.equal(2);
+        done();
+      });
+    });
+
+    it('supports nlike for no match', function(done) {
       Post.find({where: {content: {nlike: '%TestXase%'}}},
         function(err, posts) {
-          should.not.exists(err);
+          if (err) return done(err);
           posts.length.should.equal(2);
           done();
         });
     });
 
-    it('should support case insensitive queries using ilike', function(done) {
+    it('supports case insensitive queries using ilike', function(done) {
       Post.find({where: {content: {ilike: '%tesTcasE%'}}},
         function(err, posts) {
-          should.not.exist(err);
+          if (err) return done(err);
           posts.length.should.equal(1);
           posts[0].content.should.equal('T1_TestCase');
           done();
         });
     });
 
-    it('should support ilike for no match', function(done) {
+    it('supports ilike for no match', function(done) {
       Post.find({where: {content: {ilike: '%tesTxasE%'}}},
         function(err, posts) {
-          should.not.exists(err);
+          if (err) return done(err);
           posts.length.should.equal(0);
           done();
         });
     });
 
-    it('should support negative case insensitive queries using nilike',
+    it('supports negative case insensitive queries using nilike',
       function(done) {
-        Post.find({where: {content: {nilike: '%casE%'}}},
-          function(err, posts) {
-            should.not.exist(err);
-            posts.length.should.equal(0);
-            done();
-          });
+        Post.find({where: {content: {nilike: '%casE%'}}}, function(err, posts) {
+          if (err) return done(err);
+          posts.length.should.equal(0);
+          done();
+        });
       });
 
-    it('should support nilike for no match', function(done) {
+    it('supports nilike for no match', function(done) {
       Post.find({where: {content: {nilike: '%tesTxasE%'}}},
         function(err, posts) {
-          should.not.exists(err);
+          if (err) return done(err);
           posts.length.should.equal(2);
           done();
         });

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -231,21 +231,8 @@ describe('postgresql connector', function() {
   });
 
   context('pattern matching operators', function() {
-    before(function deleteTestFixtures(done) {
-      Post.destroyAll(done);
-    });
-    before(function createTextFixtures(done) {
-      Post.create([{
-        title: 't1',
-        content: 'T1_TestCase',
-      }, {
-        title: 't2',
-        content: 'T2_TheOtherCase',
-      }], done);
-    });
-    after(function deleteTestFixtures(done) {
-      Post.destroyAll(done);
-    });
+    before(deleteTestFixtures);
+    before(createTestFixtures);
 
     it('supports case sensitive queries using like', function(done) {
       Post.find({where: {content: {like: '%TestCase%'}}}, function(err, posts) {
@@ -333,6 +320,20 @@ describe('postgresql connector', function() {
           done();
         });
     });
+
+    function deleteTestFixtures(done) {
+      Post.destroyAll(done);
+    }
+
+    function createTestFixtures(done) {
+      Post.create([{
+        title: 't1',
+        content: 'T1_TestCase',
+      }, {
+        title: 't2',
+        content: 'T2_TheOtherCase',
+      }], done);
+    }
   });
 
   context('regexp operator', function() {

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -230,6 +230,121 @@ describe('postgresql connector', function() {
     });
   });
 
+  context('pattern matching operators', function() {
+    before(function deleteTestFixtures(done) {
+      Post.destroyAll(done);
+    });
+    before(function createTextFixtures(done) {
+      Post.create([{
+        title: 't1',
+        content: 'T1_TestCase',
+      }, {
+        title: 't2',
+        content: 'T2_TheOtherCase',
+      }], done);
+    });
+    after(function deleteTestFixtures(done) {
+      Post.destroyAll(done);
+    });
+
+    it('should support case sensitive queries using like',
+      function(done) {
+        Post.find({where: {content: {like: '%TestCase%'}}},
+          function(err, posts) {
+            should.not.exists(err);
+            posts.length.should.equal(1);
+            posts[0].content.should.equal('T1_TestCase');
+            done();
+          });
+      });
+
+    it('should not support case insensitive queries using like',
+      function(done) {
+        Post.find({where: {content: {like: '%tesTcasE%'}}},
+          function(err, posts) {
+            should.not.exists(err);
+            posts.length.should.equal(0);
+            done();
+          });
+      });
+
+    it('should support like for no match', function(done) {
+      Post.find({where: {content: {like: '%TestXase%'}}},
+        function(err, posts) {
+          should.not.exists(err);
+          posts.length.should.equal(0);
+          done();
+        });
+    });
+
+    it('should support negative case sensitive queries using nlike',
+      function(done) {
+        Post.find({where: {content: {nlike: '%Case%'}}},
+          function(err, posts) {
+            should.not.exists(err);
+            posts.length.should.equal(0);
+            done();
+          });
+      });
+
+    it('should not support negative case insensitive queries using nlike',
+      function(done) {
+        Post.find({where: {content: {nlike: '%casE%'}}},
+          function(err, posts) {
+            should.not.exists(err);
+            posts.length.should.equal(2);
+            done();
+          });
+      });
+
+    it('should support nlike for no match', function(done) {
+      Post.find({where: {content: {nlike: '%TestXase%'}}},
+        function(err, posts) {
+          should.not.exists(err);
+          posts.length.should.equal(2);
+          done();
+        });
+    });
+
+    it('should support case insensitive queries using ilike', function(done) {
+      Post.find({where: {content: {ilike: '%tesTcasE%'}}},
+        function(err, posts) {
+          should.not.exist(err);
+          posts.length.should.equal(1);
+          posts[0].content.should.equal('T1_TestCase');
+          done();
+        });
+    });
+
+    it('should support ilike for no match', function(done) {
+      Post.find({where: {content: {ilike: '%tesTxasE%'}}},
+        function(err, posts) {
+          should.not.exists(err);
+          posts.length.should.equal(0);
+          done();
+        });
+    });
+
+    it('should support negative case insensitive queries using nilike',
+      function(done) {
+        Post.find({where: {content: {nilike: '%casE%'}}},
+          function(err, posts) {
+            should.not.exist(err);
+            posts.length.should.equal(0);
+            done();
+          });
+      });
+
+    it('should support nilike for no match', function(done) {
+      Post.find({where: {content: {nilike: '%tesTxasE%'}}},
+        function(err, posts) {
+          should.not.exists(err);
+          posts.length.should.equal(2);
+          done();
+        });
+    });
+  });
+
   context('regexp operator', function() {
     before(function deleteTestFixtures(done) {
       Post.destroyAll(done);


### PR DESCRIPTION
### Description

Loopback-datasource-juggler added support for `ILIKE` and `NOT ILIKE` functionality in **v3.1.0**, but the PostgreSQL connector does not update to support them. This pull request adds this functionality by adding a few lines to `lib/postgresql.js` file.

#### Related issues

- strongloop/loopback-datasource-juggler#1091

Please let me if any other changes needed.
