### PR TITLE
#109 pool release fix

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -21,6 +21,7 @@ function mixinTransaction(PostgreSQL) {
     debug('Begin a transaction with isolation level: %s', isolationLevel);
     this.pg.connect(function(err, connection, done) {
       if (err) return cb(err);
+      connection.autorelease = done;
       connection.query('BEGIN TRANSACTION ISOLATION LEVEL ' + isolationLevel,
         function(err) {
           if (err) return cb(err);
@@ -63,9 +64,9 @@ function mixinTransaction(PostgreSQL) {
   };
 
   PostgreSQL.prototype.releaseConnection = function(connection, err) {
-    if (typeof connection.release === 'function') {
-      connection.release(err);
-      connection.release = null;
+    if (typeof connection.autorelease === 'function') {
+      connection.autorelease(err);
+      connection.autorelease = null;
     } else {
       var pool = this.pg;
       if (err) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -69,9 +69,9 @@ function mixinTransaction(PostgreSQL) {
     } else {
       var pool = this.pg;
       if (err) {
-        pool.destroy(connection);
+        pool.pool.destroy(connection);
       } else {
-        pool.release(connection);
+        pool.pool.release(connection);
       }
     }
   };


### PR DESCRIPTION
### Description

A combination of PR #146 which fixes #109 and a switch from explicitly calling `connection.release` to using the built-in `done` callback provided by `pg` to release connection (see [here](https://github.com/brianc/node-postgres/wiki/Transactions))

#### Related issues

- #109 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)