### PR TITLE
Allow non-id serial properties

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -264,7 +264,7 @@ function mixinMigration(PostgreSQL) {
     var self = this;
     var modelDef = this.getModelDefinition(model);
     var prop = modelDef.properties[propName];
-    if (prop.id && prop.generated) {
+    if (prop.generated) {
       return 'SERIAL';
     }
     var result = self.columnDataType(model, propName);

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -10,6 +10,7 @@ require('loopback-datasource-juggler/test/common.batch.js');
 require('loopback-datasource-juggler/test/include.test.js');
 
 require('./init');
+var async = require('async');
 var should = require('should');
 
 var Post, db, created;
@@ -496,6 +497,68 @@ describe('postgresql connector', function() {
               });
             });
       });
+    });
+  });
+});
+
+describe('Serial properties', function() {
+  var db;
+
+  before(function() {
+    db = getSchema();
+  });
+
+  it('should allow serial properties', function(done) {
+    var schema =
+      {
+        'name': 'TestInventory',
+        'options': {
+          'idInjection': false,
+          'postgresql': {
+            'schema': 'public', 'table': 'inventorytest',
+          },
+        },
+        'properties': {
+          'productId': {
+            'type': 'String', 'required': true, 'id': true,
+          },
+          'productCode': {
+            'type': 'number', 'generated': true,
+          },
+        },
+      };
+    var models = db.modelBuilder.buildModels(schema);
+    // console.log(models);
+    var Model = models['TestInventory'];
+    var count = 0;
+    Model.attachTo(db);
+
+    db.automigrate(function(err, data) {
+      async.series([
+        function(callback) {
+          Model.destroyAll(callback);
+        },
+        function(callback) {
+          Model.create({productId: 'p001'}, callback);
+        },
+        function(callback) {
+          Model.create({productId: 'p002'}, callback);
+        },
+        function(callback) {
+          Model.findOne({where: {productId: 'p001'}}, function(err, r) {
+            r.should.have.property('productId');
+            r.should.have.property('productCode', 1);
+            callback(null, r);
+          });
+        },
+        function(callback) {
+          Model.findOne({where: {productId: 'p002'}}, function(err, r) {
+            r.should.have.property('productId');
+            r.should.have.property('productCode', 2);
+            callback(null, r);
+          });
+        },
+      ], done);
     });
   });
 });

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -528,7 +528,6 @@ describe('Serial properties', function() {
         },
       };
     var models = db.modelBuilder.buildModels(schema);
-    // console.log(models);
     var Model = models['TestInventory'];
     var count = 0;
     Model.attachTo(db);


### PR DESCRIPTION
### Description

Allow properties that are not an ID to be created as `SERIAL`.

Example use-case: Using GUIDs for a primary id key but still want an auto-incrementing counter value 

#### Related issues

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
