### PR TITLE
Expose node-postgres (pg module) directly on the connector

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -88,6 +88,9 @@ function PostgreSQL(postgresql, settings) {
 // Inherit from loopback-datasource-juggler BaseSQL
 util.inherits(PostgreSQL, SqlConnector);
 
+// Expose node-postgres directly on the connector for easy access in applications
+PostgreSQL.prototype.postgresql = postgresql;
+
 PostgreSQL.prototype.debug = function() {
   if (this.settings.debug) {
     debug.apply(debug, arguments);


### PR DESCRIPTION
### Description
The problem we ran across is that  [brianc/node-postgres](https://github.com/brianc/node-postgres) parses the PG DATE type into JavaScript Dates by default instead of strings. To me, this doesn't make much sense since JS doesn't have a date-only type, but it what they decided to go with. They provide the ability to change how the values are parsed for each PG data type using types.setTypeParser (see related issue), but as far as I can tell there is no easy way to change the parser on the pg module instance that the loopback connector is using.

To make things easier from our end we configured our date model property as a String so that we can easily and accurately save dates in string form. (e.g. { exampleDate: '2016-12-20' }).

```JSON
"exampleDate": {
  "type": "String",
  "required": true,
  "length": null,
  "precision": null,
  "scale": null,
  "postgresql": {
    "columnName": "example_date",
    "dataType": "date",
    "dataLength": null,
    "dataPrecision": null,
    "dataScale": null,
    "nullable": "NO"
  }
}
```

The problem then is that we still get dates back from the ORM as JS Dates (e.g. Tue Dec 20 2016 00:00:00 GMT-0600 (CST)). This technically has the correct date portion, but when formatting it as a string there is the potential for the day to shift forward or backward because of the time in regard to the time zone if care isn't taken. If the date that was returned was Tue Dec 19 2016 18:00:00 GMT-0600 (CST) instead it may be manageable since it is technically the same point in time as the date string of '2016-12-20' (assumed to be at midnight UTC), but the way it currently works is dangerous in our case. This is for a financial system so there needs to be as small of room for error as possible.

By exposing the pg instance as "postgresql" on the connector, we are able to configure the type parser in our application like so.

(server.js or wherever)
```JavaScript
var pgDs = app.datasources.PG_DB;
if (pgDs && pgDs.connector && pgDs.connector.postgresql) {

  // Parse the postgres DATE type as a string instead of a date
  pgDs.connector.postgresql.types.setTypeParser(1082, function(val) { return String(val) });
}
```

I am sure there is a better way to accomplish this so I am open to feedback for other ways to solve this issue. I would be up for contributing some sort of parser configuration system if there was interest in it. This fix got us going but there may be concerns with exposing the pg instance to the application that I am not aware of.

Thanks in advance.

#### Related issues

(Parsing dates as strings over on the pg module issues)
brianc/node-postgres#285

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
