### PR TITLE
Add ability to dynamically change schema based on request context

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -15,6 +15,7 @@ var ParameterizedSQL = SqlConnector.ParameterizedSQL;
 var util = require('util');
 var debug = require('debug')('loopback:connector:postgresql');
 var Promise = require('bluebird');
+var LoopBackContext = require('loopback-context');
 
 /**
  *
@@ -391,8 +392,15 @@ PostgreSQL.prototype.escapeValue = function(value) {
   return value;
 };
 
+function getSchemaFromContext(settings) {
+  if (settings.contextSchema) {
+    return LoopBackContext.getCurrentContext().get(settings.contextSchema)
+  }
+  return null;
+}
+
 PostgreSQL.prototype.tableEscaped = function(model) {
-  var schema = this.schema(model) || 'public';
+  var schema = getSchemaFromContext(this.settings) || this.schema(model) || 'public';
   return this.escapeName(schema) + '.' +
     this.escapeName(this.table(model));
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "loopback-connector": "^4.0.0",
     "pg": "^6.0.0",
     "strong-globalize": "^2.6.2",
+    "loopback-context": "^3.0.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The following shows our use case:

in `datasources.json`:
```
{
  "postgres": {
    "host": "postgres",
    "port": 5432,
    "url": "",
    "database": "",
    "password": "",
    "name": "postgres",
    "user": "",
    "connector": "postgresql",
    "contextSchema": "schema"
  }
}
```

and `mixins/schema-changes.js`
```
var LoopBackContext = require('loopback-context');

function getSubdomain(ctx) {
  var parts = ctx.req.headers.host.split('.');
  if (parts.length === 3) {
    return parts[0];
  }
  return null;
}

module.exports = function(model, debug) {
  model.beforeRemote('**', function(ctx, unused, next) {
    var schema = getSubdomain(ctx);
    if (schema) {
      LoopBackContext.getCurrentContext().set('schema', schema);
    }
    next();
  });
};
```
