### PR TITLE
Fix bug when using postgresql 8.x

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -387,10 +387,10 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
     operatorValue, propertyDefinition) {
   switch (operator) {
     case 'like':
-      return new ParameterizedSQL(columnName + " LIKE ? ESCAPE '\\\\'",
+      return new ParameterizedSQL(columnName + " LIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
     case 'nlike':
-      return new ParameterizedSQL(columnName + " NOT LIKE ? ESCAPE '\\\\'",
+      return new ParameterizedSQL(columnName + " NOT LIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
     case 'regexp':
       if (operatorValue.global)

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -387,10 +387,10 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
     operatorValue, propertyDefinition) {
   switch (operator) {
     case 'like':
-      return new ParameterizedSQL(columnName + " LIKE ? ESCAPE '\\'",
+      return new ParameterizedSQL(columnName + " LIKE ? ESCAPE '\\\\'",
           [operatorValue]);
     case 'nlike':
-      return new ParameterizedSQL(columnName + " NOT LIKE ? ESCAPE '\\'",
+      return new ParameterizedSQL(columnName + " NOT LIKE ? ESCAPE '\\\\'",
           [operatorValue]);
     case 'regexp':
       if (operatorValue.global)


### PR DESCRIPTION
BUG: error: unterminated quoted string at or near \"'\\' ORDER BY \"uuid\"\"
when using like filter.
eg. { where: {name: {like: "%abc%"}}}

