### PR TITLE
Fix operations on ended transactions

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -197,12 +197,12 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   if (transaction && transaction.connector === this) {
     if (!transaction.connection) {
       return process.nextTick(function() {
-        callback(new Error(g.f('Connection does not exist')))
+        callback(new Error(g.f('Connection does not exist')));
       });
     }
     if (transaction.txId !== transaction.connection.txId) {
       return process.nextTick(function() {
-        callback(new Error(g.f('Transaction is not active')))
+        callback(new Error(g.f('Transaction is not active')));
       });
     }
     debug('Execute SQL within a transaction');

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -194,8 +194,13 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   }
 
   var transaction = options.transaction;
-  if (transaction && transaction.connection &&
-    transaction.connector === this) {
+  if (transaction && transaction.connector === this) {
+    if (!transaction.connection) {
+      return callback(new Error(g.f('Connection does not exist')));
+    }
+    if (transaction.txId !== transaction.connection.txId) {
+      return callback(new Error(g.f('Transaction is not active')));
+    }
     debug('Execute SQL within a transaction');
     // Do not release the connection
     executeWithConnection(transaction.connection, null);

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -196,10 +196,14 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   var transaction = options.transaction;
   if (transaction && transaction.connector === this) {
     if (!transaction.connection) {
-      return callback(new Error(g.f('Connection does not exist')));
+      return process.nextTick(function() {
+        callback(new Error(g.f('Connection does not exist')))
+      });
     }
     if (transaction.txId !== transaction.connection.txId) {
-      return callback(new Error(g.f('Transaction is not active')));
+      return process.nextTick(function() {
+        callback(new Error(g.f('Transaction is not active')))
+      });
     }
     debug('Execute SQL within a transaction');
     // Do not release the connection

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -5,6 +5,8 @@
 
 'use strict';
 var debug = require('debug')('loopback:connector:postgresql:transaction');
+var uuid = require('uuid');
+var Transaction = require('loopback-connector').Transaction;
 
 module.exports = mixinTransaction;
 
@@ -18,6 +20,7 @@ function mixinTransaction(PostgreSQL) {
    * @param cb
    */
   PostgreSQL.prototype.beginTransaction = function(isolationLevel, cb) {
+    var connector = this;
     debug('Begin a transaction with isolation level: %s', isolationLevel);
     this.pg.connect(function(err, connection, done) {
       if (err) return cb(err);
@@ -25,7 +28,10 @@ function mixinTransaction(PostgreSQL) {
       connection.query('BEGIN TRANSACTION ISOLATION LEVEL ' + isolationLevel,
         function(err) {
           if (err) return cb(err);
-          cb(null, connection);
+          var tx = new Transaction(connector, connection);
+          tx.txId = uuid.v1();
+          connection.txId = tx.txId;
+          cb(null, tx);
         });
     });
   };
@@ -65,6 +71,7 @@ function mixinTransaction(PostgreSQL) {
 
   PostgreSQL.prototype.releaseConnection = function(connection, err) {
     if (typeof connection.autorelease === 'function') {
+      connection.txId = null;
       connection.autorelease(err);
       connection.autorelease = null;
     } else {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "debug": "^2.1.1",
     "loopback-connector": "^4.0.0",
     "pg": "^6.0.0",
-    "strong-globalize": "^2.6.2"
+    "strong-globalize": "^2.6.2",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/test/init.js
+++ b/test/init.js
@@ -29,6 +29,7 @@ if (process.env.CI) {
       'emptytest',
     username: process.env.PGUSER,
     password: process.env.PGPASSWORD,
+    poolSize: 100,
   };
 }
 

--- a/test/init.js
+++ b/test/init.js
@@ -29,7 +29,6 @@ if (process.env.CI) {
       'emptytest',
     username: process.env.PGUSER,
     password: process.env.PGPASSWORD,
-    poolSize: 100,
   };
 }
 

--- a/test/postgresql.transaction.test.js
+++ b/test/postgresql.transaction.test.js
@@ -131,9 +131,9 @@ describe('transactions', function() {
 
     it('should throw an error when creating in a committed transaction', function(done) {
       currentTx.commit(function(err) {
-        if(err) return done(err);
+        if (err) return done(err);
         Post.create({title: 't4', content: 'c4'}, {transaction: currentTx}, function(err, post) {
-          if(!err) return done(new Error('should throw error'));
+          if (!err) return done(new Error('should throw error'));
           done();
         });
       });
@@ -141,9 +141,9 @@ describe('transactions', function() {
 
     it('should throw an error when creating in a rolled back transaction', function(done) {
       currentTx.rollback(function(err) {
-        if(err) return done(err);
+        if (err) return done(err);
         Post.create({title: 't4', content: 'c4'}, {transaction: currentTx}, function(err, post) {
-          if(!err) return done(new Error('should throw error'));
+          if (!err) return done(new Error('should throw error'));
           done();
         });
       });

--- a/test/postgresql.transaction.test.js
+++ b/test/postgresql.transaction.test.js
@@ -124,4 +124,29 @@ describe('transactions', function() {
 
     it('should not see the rolledback insert', expectToFindPosts(post, 0));
   });
+
+  describe('finished', function() {
+    var post = {title: 't2', content: 'c2'};
+    beforeEach(createPostInTx(post));
+
+    it('should throw an error when creating in a committed transaction', function(done) {
+      currentTx.commit(function(err) {
+        if(err) return done(err);
+        Post.create({title: 't4', content: 'c4'}, {transaction: currentTx}, function(err, post) {
+          if(!err) return done(new Error('should throw error'));
+          done();
+        });
+      });
+    });
+
+    it('should throw an error when creating in a rolled back transaction', function(done) {
+      currentTx.rollback(function(err) {
+        if(err) return done(err);
+        Post.create({title: 't4', content: 'c4'}, {transaction: currentTx}, function(err, post) {
+          if(!err) return done(new Error('should throw error'));
+          done();
+        });
+      });
+    });
+  });
 });

--- a/test/postgresql.transaction.test.js
+++ b/test/postgresql.transaction.test.js
@@ -71,11 +71,11 @@ describe('transactions', function() {
             Post.create(post, {transaction: tx},
               function(err, p) {
                 if (err) {
-                  done(err);
+                  return done(err);
                 } else {
                   tx.commit(function(err) {
                     if (err) {
-                      done(err);
+                      return done(err);
                     }
                     completed++;
                     checkResults();


### PR DESCRIPTION
### Description

*Issue*

This fixes a pretty critical issue where operations can occur on non-transactional connections when the user expects them to land in a transaction. Tests added which fail on master but pass here.

*Example use case*:

- Begin a transaction.
- Perform some creates on the transaction
- An external event (e.g. timeout) triggers a rollback
- Additional creates are allowed to continue despite the transaction no longer being active
- These creates still hit the database when the programmer expects them not to as the transaction has rolled back (finished)

*Solution*:

I've added a uuid to each transaction which exists on the transaction itself and is tagged onto the current connection. Whenever the transaction is committed or rolled back ('finished') the id is removed from the connection but remains on the transaction. Any attempts to execute sql on the transaction checks the transaction id against the specified connection and will fail if the ids do not match.

#### Related issues

- #129

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
