### PR TITLE
Monkey patch the generic-pool to continue working through errors

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -50,6 +50,38 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 };
 
+// there is a bug in the generic pool where it will not recreate
+// destroyed workers (even if there is waiting work to do) unless
+// there is a min specified. Make sure we keep some connections
+// SEE: https://github.com/coopernurse/node-pool/pull/186
+// SEE: https://github.com/brianc/node-pg-pool/issues/48
+// SEE: https://github.com/strongloop/loopback-connector-postgresql/issues/231
+function _ensureMinimum() {
+  var i, diff, waiting;
+  if (this._draining) return;
+  waiting = this._waitingClients.size();
+  if (this._factory.min > 0) { // we have positive specified minimum
+    diff = this._factory.min - this._count;
+  } else if (waiting > 0) { // we have no minimum, but we do have work to do
+    diff = Math.min(waiting, this._factory.max - this._count);
+  }
+  for (i = 0; i < diff; i++) {
+    this._createResource();
+  }
+};
+function makePool(options) {
+  var pg = new postgresql.Pool(options);
+  // Monkey patch to ensure we always finish our work
+  //  - There is a bug where callbacks go uncalled if min is not set
+  //  - We might still not want a connection to *always* exist
+  //  - but we do want to create up to max connections if we have work
+  //  - still waiting
+  // This should be safe till the version of pg-pool is upgraded
+  // SEE: https://github.com/coopernurse/node-pool/pull/186
+  pg.pool._ensureMinimum = _ensureMinimum;
+  return pg;
+}
+
 /**
  * PostgreSQL connector constructor
  *
@@ -78,7 +110,8 @@ function PostgreSQL(postgresql, settings) {
     this.clientConfig.connectionString = settings.url;
   }
   this.clientConfig.Promise = Promise;
-  this.pg = new postgresql.Pool(this.clientConfig);
+  this.pg = makePool(this.clientConfig);
+
   this.settings = settings;
   if (settings.debug) {
     debug('Settings %j', settings);


### PR DESCRIPTION

### Description

 * previously without a minimum the pool would stop handling database
   requests due to worker exhaustion (for any requests started before
   worker exhaustion)
 * This patch ensures that if we have waiting work, we will continue
   processing it
 * a test that fails before this patch and succeeds after this patch:
  'postgresql connector errors'


#### Related issues

#231 Default for minimum pool size: After 10 Errors DB stops working 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
