### PR TITLE
Fix the escape char

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -387,13 +387,13 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
       return new ParameterizedSQL(columnName + " LIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
     case 'ilike':
-      return new ParameterizedSQL(columnName + " ILIKE ? ESCAPE '\\'",
+      return new ParameterizedSQL(columnName + " ILIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
     case 'nlike':
       return new ParameterizedSQL(columnName + " NOT LIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
     case 'nilike':
-      return new ParameterizedSQL(columnName + " NOT ILIKE ? ESCAPE '\\'",
+      return new ParameterizedSQL(columnName + " NOT ILIKE ? ESCAPE E'\\\\'",
           [operatorValue]);
     case 'regexp':
       if (operatorValue.global)


### PR DESCRIPTION
### Description

The current code fails the tests due to invalid escape chars.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
