### PR TITLE
Added a debugging namespace for data

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -14,6 +14,7 @@ var SqlConnector = require('loopback-connector').SqlConnector;
 var ParameterizedSQL = SqlConnector.ParameterizedSQL;
 var util = require('util');
 var debug = require('debug')('loopback:connector:postgresql');
+var debugData = require('debug')('loopback:connector:postgresql:data');
 var Promise = require('bluebird');
 
 /**
@@ -171,7 +172,9 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
       if (err && self.settings.debug) {
         self.debug(err);
       }
-      if (self.settings.debug && data) self.debug('%j', data);
+      if (self.settings.debug && data) {
+        debugData('%j', data);
+      }
       if (done) {
         process.nextTick(function() {
           // Release the connection in next tick


### PR DESCRIPTION
Fix for https://github.com/strongloop/loopback-connector-postgresql/issues/241
Added debugData so that data is debugged using different debugging namespace. 

To see data, you should put to your DEBUG environment variable "loopback:connector:postgresql*" or "loopback:connector:postgresql:data". By default, data will not be debugged.