### PR TITLE
Reuse the data source to avoid too many clients

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -43,9 +43,14 @@ global.getDBConfig = function(useUrl) {
   };
   return settings;
 };
+
+var db;
 global.getDataSource = global.getSchema = function(useUrl) {
+  // Return cached data source if possible to avoid too many client error
+  // due to multiple instances of connection pools
+  if (!useUrl && db) return db;
   var settings = getDBConfig(useUrl);
-  var db = new DataSource(require('../'), settings);
+  db = new DataSource(require('../'), settings);
   db.log = function(a) {
     // console.log(a);
   };


### PR DESCRIPTION
### Description

A lot of tests from juggler calls `getDataSource/getSchema` to set up the DB connections without disconnecting them. As a result, postgresql connector tests run out of client connections. This PR allows the reuse of ds.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
