### PR TITLE
dbdefaults: Cleanup InvalidDefault def after test

### DIFF
--- a/test/postgresql.dbdefaults.test.js
+++ b/test/postgresql.dbdefaults.test.js
@@ -34,7 +34,7 @@ describe('database default field values', function() {
       created: {
         type: 'Date',
         postgresql: {
-          dbDefault: "'5'",
+          dbDefault: '\'5\'',
         },
       },
     });
@@ -49,6 +49,9 @@ describe('database default field values', function() {
   it('should report inconsistent default values used', function(done) {
     db.automigrate('PostWithInvalidDbDefaultValue', function(err) {
       should.exists(err);
+      // XXX(kjdelisle): The InvalidDefaults test is polluting the default date
+      // types of the other tests!
+      delete db.connector._models.PostWithInvalidDbDefaultValue;
       done();
     });
   });


### PR DESCRIPTION
### Description

After switching to a single DataSource instance for the tests, the
InvalidDefault definition remains in the connector's _models
collection. Removed this definition to allow use of db.automigrate
in subsequent tests.



