### PR TITLE
Add loopback-connector into peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,18 @@
     "async": "^0.9.0",
     "bluebird": "^3.4.6",
     "debug": "^2.1.1",
-    "loopback-connector": "^4.0.0",
     "pg": "^6.0.0",
     "strong-globalize": "^2.6.2",
     "uuid": "^3.0.1"
   },
+  "peerDependencies": {
+    "loopback-connector": "^4.0.0",
+    "loopback-datasource-juggler": "^3.0.0"
+  },
   "devDependencies": {
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
+    "loopback-connector": "^4.0.0",
     "loopback-datasource-juggler": "^3.0.0",
     "mocha": "^2.1.0",
     "rc": "^1.0.0",


### PR DESCRIPTION
### Description

 * by listing loopback-connector as a dependency it will be loaded
   as a submodule by loopback-connector-postgres when used in a
   parent loopback project.  Because we reference objects/constructors
   out of loopback-connector, and ask isinstance style questions of
   them, they need to resolve to the same constructor

EG:
 * App uses loopback-connector and loopback-connector-postgres
 * App wishes to generate a loopback-connector.ParameterizedSQL and
   pass it to buildDefinition (a where clause), but it is not the same
   ParameterizedSQL object (even if loaded from the same lib/version),
   because it is in the sub node_packages

NB: this patch should probably be mirrored in loopback-datasource-juggler
To effectively share object models, everyone needs to load the same
library from the same spot.

loopback loads loopback-datasource-juggler (and should also load
loopback-connector) and any particular app will choose the backend
loopback-connector-postgres, we want all of these libs to refer to the
same objects

### Testing

Since this only happens in concert with other libraries and dependency chains I was not sure how to add a unit/integration test to this project about it.  That said "peerDependencies" seems to have been exactly created for this purpose


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
