### PR TITLE
Revert "Add loopback-connector into peer dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,14 @@
     "async": "^0.9.0",
     "bluebird": "^3.4.6",
     "debug": "^2.1.1",
+    "loopback-connector": "^4.0.0",
     "pg": "^6.0.0",
     "strong-globalize": "^2.6.2",
     "uuid": "^3.0.1"
   },
-  "peerDependencies": {
-    "loopback-connector": "^4.0.0",
-    "loopback-datasource-juggler": "^3.0.0"
-  },
   "devDependencies": {
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
-    "loopback-connector": "^4.0.0",
     "loopback-datasource-juggler": "^3.0.0",
     "mocha": "^2.1.0",
     "rc": "^1.0.0",


### PR DESCRIPTION
Revert back strongloop/loopback-connector-postgresql#246 due to `loopback` requiring `loopback-connector` as a default dependency through this module.

connect to https://github.com/strongloop/loopback-workspace/issues/487