### PR TITLE
Add test case for order by random

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -568,6 +568,14 @@ PostgreSQL.prototype.getCountForAffectedRows = function(model, info) {
   return info && info.affectedRows;
 };
 
+/**
+ * Build order by random
+ * @returns {string} the order by rand() statement
+ */
+PostgreSQL.prototype.buildOrderByRandom = function() {
+  return 'ORDER BY RAND()';
+};
+
 require('./discovery')(PostgreSQL);
 require('./migration')(PostgreSQL);
 require('./transaction')(PostgreSQL);

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -570,10 +570,10 @@ PostgreSQL.prototype.getCountForAffectedRows = function(model, info) {
 
 /**
  * Build order by random
- * @returns {string} the order by rand() statement
+ * @returns {string} the `order by random()` statement
  */
 PostgreSQL.prototype.buildOrderByRandom = function() {
-  return 'ORDER BY RAND()';
+  return 'ORDER BY RANDOM()';
 };
 
 require('./discovery')(PostgreSQL);

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -132,12 +132,12 @@ describe('postgresql connector', function() {
   });
 
   it('should support order with random sorting', function(done) {
-    Post.find({order: 'rand'}, function(err, randomPosts1) {
+    Post.find({order: '${random}'}, function(err, randomPosts1) {
       should.not.exists(err);
       var order1 = randomPosts1.map(function(u) { return u.id; });
       (order1.length).should.eql(randomPosts1.length);
       order1.should.containEql(1, 2, 3);
-      Post.find({order: 'rand'}, function(err, randomPosts2) {
+      Post.find({order: '${random}'}, function(err, randomPosts2) {
         should.not.exist(err);
         var order2 = randomPosts2.map(function(u) { return u.id; });
         (order2.length).should.eql(randomPosts2.length);

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -131,6 +131,24 @@ describe('postgresql connector', function() {
       });
   });
 
+  it('should support order with random sorting', function(done) {
+    Post.find({order: 'rand'}, function(err, randomPosts1) {
+      should.not.exists(err);
+      var order1 = randomPosts1.map(function(u) { return u.id; });
+      (order1.length).should.eql(randomPosts1.length);
+      order1.should.containEql(1, 2, 3);
+      Post.find({order: 'rand'}, function(err, randomPosts2) {
+        should.not.exist(err);
+        var order2 = randomPosts2.map(function(u) { return u.id; });
+        (order2.length).should.eql(randomPosts2.length);
+        order2.should.containEql(1, 2, 3);
+         //Though it is a possibility, but probability is very low.
+        should(order1).not.eql(order2);
+        done();
+      });
+    });
+  });
+
   it('should support date types with eq', function(done) {
     Post.find({
       where: {created: created},


### PR DESCRIPTION
### Description
Add order by rand () for postgresql connector.
tests couldn't be unified in juggler since they are code specific and they work only for 4 connectors. 

#### Related issues

connect to https://github.com/strongloop/loopback/issues/902
To test feature in pr: https://github.com/strongloop/loopback-connector/pull/102
Original PR that cannot be used since the function is completely refactored
https://github.com/strongloop/loopback-connector-mysql/pull/62

### Checklist


- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

