### PR TITLE
Fix geo operator

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -486,6 +486,148 @@ PostgreSQL.prototype.getInsertedId = function(model, info) {
   return idValue;
 };
 
+/**
+ * Build the SQL WHERE clause for the where object
+ * @param {string} model Model name
+ * @param {object} where An object for the where conditions
+ * @returns {ParameterizedSQL} The SQL WHERE clause
+ */
+PostgreSQL.prototype.buildWhere = function(model, where) {
+  var whereClause = this._buildWhere(model, where);
+  if (whereClause.sql) {
+    whereClause.sql = 'WHERE ' + whereClause.sql;
+  }
+  return whereClause;
+};
+
+/**
+ * @private
+ * @param model
+ * @param where
+ * @returns {ParameterizedSQL}
+ */
+PostgreSQL.prototype._buildWhere = function(model, where) {
+  var columnValue, sqlExp;
+  if (!where) {
+    return new ParameterizedSQL('');
+  }
+  if (typeof where !== 'object' || Array.isArray(where)) {
+    debug('Invalid value for where: %j', where);
+    return new ParameterizedSQL('');
+  }
+  var self = this;
+  var props = self.getModelDefinition(model).properties;
+
+  var whereStmts = [];
+  for (var key in where) {
+    var stmt = new ParameterizedSQL('', []);
+    // Handle and/or operators
+    if (key === 'and' || key === 'or') {
+      var branches = [];
+      var branchParams = [];
+      var clauses = where[key];
+      if (Array.isArray(clauses)) {
+        for (var i = 0, n = clauses.length; i < n; i++) {
+          var stmtForClause = self._buildWhere(model, clauses[i]);
+          if (stmtForClause.sql) {
+            stmtForClause.sql = '(' + stmtForClause.sql + ')';
+            branchParams = branchParams.concat(stmtForClause.params);
+            branches.push(stmtForClause.sql);
+          }
+        }
+        stmt.merge({
+          sql: branches.join(' ' + key.toUpperCase() + ' '),
+          params: branchParams,
+        });
+        whereStmts.push(stmt);
+        continue;
+      }
+      // The value is not an array, fall back to regular fields
+    }
+    var p = props[key];
+    if (p == null) {
+      // Unknown property, ignore it
+      debug('Unknown property %s is skipped for model %s', key, model);
+      continue;
+    }
+    // eslint-disable one-var
+    var expression = where[key];
+    var columnName = self.columnEscaped(model, key);
+    // eslint-enable one-var
+    if (expression === null || expression === undefined) {
+      stmt.merge(columnName + ' IS NULL');
+    } else if (expression && expression.constructor === Object) {
+      var operator = Object.keys(expression)[0];
+      // Get the expression without the operator
+      expression = expression[operator];
+      if (operator === 'inq' || operator === 'nin' || operator === 'between') {
+        columnValue = [];
+        if (Array.isArray(expression)) {
+          // Column value is a list
+          for (var j = 0, m = expression.length; j < m; j++) {
+            columnValue.push(this.toColumnValue(p, expression[j]));
+          }
+        } else {
+          columnValue.push(this.toColumnValue(p, expression));
+        }
+        if (operator === 'between') {
+          // BETWEEN v1 AND v2
+          var v1 = columnValue[0] === undefined ? null : columnValue[0];
+          var v2 = columnValue[1] === undefined ? null : columnValue[1];
+          columnValue = [v1, v2];
+        } else {
+          // IN (v1,v2,v3) or NOT IN (v1,v2,v3)
+          if (columnValue.length === 0) {
+            if (operator === 'inq') {
+              columnValue = [null];
+            } else {
+              // nin () is true
+              continue;
+            }
+          }
+        }
+      } else if (operator === 'regexp' && expression instanceof RegExp) {
+        // do not coerce RegExp based on property definitions
+        columnValue = expression;
+      } else {
+        columnValue = this.toColumnValue(p, expression);
+      }
+      sqlExp = self.buildExpression(columnName, operator, columnValue, p);
+      stmt.merge(sqlExp);
+    } else {
+      // The expression is the field value, not a condition
+      columnValue = self.toColumnValue(p, expression);
+      if (columnValue === null) {
+        stmt.merge(columnName + ' IS NULL');
+      } else {
+        if (columnValue instanceof ParameterizedSQL) {
+          if (p.type.name === 'GeoPoint')
+            stmt.merge(columnName + '~=').merge(columnValue);
+          else
+            stmt.merge(columnName + '=').merge(columnValue);
+        } else {
+          stmt.merge({
+            sql: columnName + '=?',
+            params: [columnValue],
+          });
+        }
+      }
+    }
+    whereStmts.push(stmt);
+  }
+  var params = [];
+  var sqls = [];
+  for (var k = 0, s = whereStmts.length; k < s; k++) {
+    sqls.push(whereStmts[k].sql);
+    params = params.concat(whereStmts[k].params);
+  }
+  var whereStmt = new ParameterizedSQL({
+    sql: sqls.join(' AND '),
+    params: params,
+  });
+  return whereStmt;
+};
+
 /*!
  * Convert property name/value to an escaped DB column value
  * @param {Object} prop Property descriptor


### PR DESCRIPTION
### Description

Currently, postgresql does not support filtering geopoint fields. This is because postgresql uses the base connector level **buildWhere** function to build the query. Not all SQL connectors have the exact way to compare geopoint values and that is why postgresql fails.

This PR overrides two SQL connector functions **buildWhere** and **_buildWhere** functions and adds the additional check

```js
if (p.type.name === 'GeoPoint')
   stmt.merge(columnName + '~=').merge(columnValue);
```

connect to https://github.com/strongloop/loopback-connector-postgresql/issues/126