### PR TITLE
Allow to debug queries only

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -14,6 +14,7 @@ var SqlConnector = require('loopback-connector').SqlConnector;
 var ParameterizedSQL = SqlConnector.ParameterizedSQL;
 var util = require('util');
 var debug = require('debug')('loopback:connector:postgresql');
+var debugData = require('debug')('loopback:connector:postgresql:data');
 var Promise = require('bluebird');
 
 /**
@@ -33,7 +34,6 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   var dbSettings = dataSource.settings || {};
   dbSettings.host = dbSettings.host || dbSettings.hostname || 'localhost';
   dbSettings.user = dbSettings.user || dbSettings.username;
-  dbSettings.debug = dbSettings.debug || debug.enabled;
 
   dataSource.connector = new PostgreSQL(postgresql, dbSettings);
   dataSource.connector.dataSource = dataSource;
@@ -113,19 +113,11 @@ function PostgreSQL(postgresql, settings) {
   this.pg = makePool(this.clientConfig);
 
   this.settings = settings;
-  if (settings.debug) {
-    debug('Settings %j', settings);
-  }
+  debug('Settings %j', settings);
 }
 
 // Inherit from loopback-datasource-juggler BaseSQL
 util.inherits(PostgreSQL, SqlConnector);
-
-PostgreSQL.prototype.debug = function() {
-  if (this.settings.debug) {
-    debug.apply(debug, arguments);
-  }
-};
 
 PostgreSQL.prototype.getDefaultSchemaName = function() {
   return 'public';
@@ -157,21 +149,17 @@ PostgreSQL.prototype.connect = function(callback) {
 PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   var self = this;
 
-  if (self.settings.debug) {
-    if (params && params.length > 0) {
-      self.debug('SQL: %s\nParameters: %j', sql, params);
-    } else {
-      self.debug('SQL: %s', sql);
-    }
+  if (params && params.length > 0) {
+    debug('SQL: %s\nParameters: %j', sql, params);
+  } else {
+    debug('SQL: %s', sql);
   }
 
   function executeWithConnection(connection, done) {
     connection.query(sql, params, function(err, data) {
       // if(err) console.error(err);
-      if (err && self.settings.debug) {
-        self.debug(err);
-      }
-      if (self.settings.debug && data) self.debug('%j', data);
+      if (err) debug(err);
+      if (data) debugData('%j', data);
       if (done) {
         process.nextTick(function() {
           // Release the connection in next tick
@@ -460,9 +448,7 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
  */
 PostgreSQL.prototype.disconnect = function disconnect(cb) {
   if (this.pg) {
-    if (this.settings.debug) {
-      this.debug('Disconnecting from ' + this.settings.hostname);
-    }
+    debug('Disconnecting from ' + this.settings.hostname);
     var pg = this.pg;
     this.pg = null;
     pg.end();  // This is sync


### PR DESCRIPTION
### Description

If you set the debug statement in postgresql it is prints to console both queries and data returned from the database.

This PR adds another query scope to only log data :
- `loopback:connector:postgresql:data`

Use the default one `loopback:connector:postgresql` to just log queries.

connected to https://github.com/strongloop/loopback-connector-postgresql/issues/241