### PR TITLE
Fix alter property in autoupdate

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -194,6 +194,8 @@ function mixinMigration(PostgreSQL) {
   PostgreSQL.prototype.modifyDatatypeInActual = function(model, propName) {
     var self = this;
     var sqlCommand = self.columnEscaped(model, propName) + ' TYPE ' +
+      self.columnDataType(model, propName) + ' USING ' +
+      self.columnEscaped(model, propName) + '::' +
       self.columnDataType(model, propName);
     return sqlCommand;
   };


### PR DESCRIPTION
### Description

When using **autoupdate** and altering a column property type, for example from `String` type to `Date`, postgresql requires explicit type casting. This fix allows the connector to handle the type casting when doing such alteration.

connect to https://github.com/strongloop/loopback-connector-postgresql/issues/217