### PR TITLE
Bug in `double precision/real` data type

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -110,6 +110,47 @@ function mixinDiscovery(PostgreSQL) {
     };
   };
 
+  /**
+    * Discover model properties from a table
+    * @param {String} table The table name
+    * @param {Object} options The options for discovery
+    * @param {Function} [cb] The callback function
+  */
+  PostgreSQL.prototype.discoverModelProperties = function(table, options, cb) {
+    var self = this;
+    var args = self.getArgs(table, options, cb);
+    var schema = args.schema;
+
+    table = args.table;
+    options = args.options;
+
+    if (!schema) {
+      schema = self.getDefaultSchema();
+    }
+
+    self.setDefaultOptions(options);
+    cb = args.cb;
+
+    var sql = self.buildQueryColumns(schema, table);
+    var callback = function(err, results) {
+      if (err) {
+        cb(err, results);
+      } else {
+        results.map(function(r) {
+          // PostgreSQL accepts float(1) to float(24) as selecting the `real` type,
+          // while float(25) to float(53) select `double precision`
+          // https://www.postgresql.org/docs/9.4/static/datatype-numeric.html
+          if (r.dataType === 'real' || r.dataType === 'double precision')
+            r.dataType = 'float';
+          r.type = self.buildPropertyType(r, options);
+          self.setNullableProperty(r);
+        });
+        cb(err, results);
+      }
+    };
+    this.execute(sql, callback);
+  };
+
   /*!
    * Build the sql statement to query columns for a given table
    * @param owner

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
+    "lodash": "^4.17.4",
     "loopback-datasource-juggler": "^3.0.0",
     "mocha": "^2.1.0",
     "rc": "^1.0.0",


### PR DESCRIPTION
### Description
If I have an existing table in PostgreSQL with fields with either of type **double precision** or **real**, then discover the table schema as a loopback model, change the model definition and then perform autoupdate, PostgreSQL will throw an error. 

This is because by default, the **double precision** has a precision set to 53 and **real** has a precision set to 24 in postgres and neither of the data types accept parameterized precision values. Both of **double precision** and **real** are child types of **float** which takes parameterized values to determine the children type. 

i.e `float(n)` if n >=1 and n <=24 it is of type **real** and if n >=25 and n <= 53, it is of type **double precision**. Read more [here](https://www.postgresql.org/docs/9.4/static/datatype-numeric.html)

Since neither **double precision** nor **real** takes a parameterized value for specifying the precision (the precision is automatically set by using **float** data type) but has a default precision value, autoupdate fails. 

This fix overrides the  `discoverModelProperties` from [base connector](https://github.com/strongloop/loopback-connector/blob/master/lib/sql.js#L1877) and changes the data type to **float** if the data type is either **double precision** or **real**.

fixes https://github.com/strongloop/loopback-connector-postgresql/issues/282