### PR TITLE
Fix integer data type

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -142,6 +142,12 @@ function mixinDiscovery(PostgreSQL) {
           // https://www.postgresql.org/docs/9.4/static/datatype-numeric.html
           if (r.dataType === 'real' || r.dataType === 'double precision')
             r.dataType = 'float';
+          // Set data precision to be `null` if the data type is either integer,
+          // bigint or smallint. This is to avoid syntax errors when updating/migrating
+          // model with a discovered schema that consists of those data types
+          if (r.dataType === 'integer' || r.dataType === 'bigint'
+            || r.dataType === 'smallint')
+            r.dataPrecision = null;
           r.type = self.buildPropertyType(r, options);
           self.setNullableProperty(r);
         });

--- a/test/postgresql.discover.test.js
+++ b/test/postgresql.discover.test.js
@@ -109,13 +109,15 @@ describe('Discover model properties', function() {
   before(function(done) {
     City = db.define('City', {
       name: {type: String},
-      code: {type: String},
       lng: {type: Number, postgresql: {
         dataType: 'double precision',
       }},
       lat: {type: Number, postgresql: {
         dataType: 'real',
       }},
+      code: {type: Number},
+      population: {type: Number, postgresql: {dataType: 'bigint'}},
+      currency: {type: Number, postgresql: {dataType: 'smallint'}},
     });
     db.automigrate(done);
   });
@@ -133,8 +135,50 @@ describe('Discover model properties', function() {
         return prop.dataType;
       });
       assert(dataTypes);
+      assert.equal(dataTypes[1], 'float');
       assert.equal(dataTypes[2], 'float');
-      assert.equal(dataTypes[3], 'float');
+      done();
+    });
+  });
+
+  it('drops precision from a field which is `integer`', function(done) {
+    db.discoverModelProperties('city', function(err, properties) {
+      assert(!err);
+      assert(properties);
+      var prop = _.find(properties, function(prop) {
+        return prop.columnName === 'code';
+      });
+      assert(prop);
+      assert.equal(prop.dataType, 'integer');
+      assert(!prop.dataPrecision);
+      done();
+    });
+  });
+
+  it('drops precision from a field which is `bigint`', function(done) {
+    db.discoverModelProperties('city', function(err, properties) {
+      assert(!err);
+      assert(properties);
+      var prop = _.find(properties, function(prop) {
+        return prop.columnName === 'population';
+      });
+      assert(prop);
+      assert.equal(prop.dataType, 'bigint');
+      assert(!prop.dataPrecision);
+      done();
+    });
+  });
+
+  it('drops precision from a field which is `smallint`', function(done) {
+    db.discoverModelProperties('city', function(err, properties) {
+      assert(!err);
+      assert(properties);
+      var prop = _.find(properties, function(prop) {
+        return prop.columnName === 'currency';
+      });
+      assert(prop);
+      assert.equal(prop.dataType, 'smallint');
+      assert(!prop.dataPrecision);
       done();
     });
   });
@@ -155,13 +199,21 @@ describe('Discover model properties', function() {
           assert(!err);
           assert(columns);
           var cols = _.filter(columns, function(col) {
-            return col.dataType === 'real' || col.dataType === 'double precision';
+            return col.dataType === 'real' ||
+            col.dataType === 'double precision' || col.dataType === 'integer'
+            || col.dataType === 'bigint' || col.dataType === 'smallint';
           });
           assert(cols);
           assert.equal(cols[0].columnName, 'lng');
           assert.equal(cols[0].dataType, 'double precision');
           assert.equal(cols[1].columnName, 'lat');
           assert.equal(cols[1].dataType, 'real');
+          assert.equal(cols[2].columnName, 'code');
+          assert.equal(cols[2].dataType, 'integer');
+          assert.equal(cols[3].columnName, 'population');
+          assert.equal(cols[3].dataType, 'bigint');
+          assert.equal(cols[4].columnName, 'currency');
+          assert.equal(cols[4].dataType, 'smallint');
           done();
         });
       });


### PR DESCRIPTION
# Description

When you have an existing table in the database with data types of either **integer**, **bigint** or **smallint** and discover the model definition of that table, it returns back the built-in storage precision of those data types. For example, `smallint` will have a data precision of 16 because the storage size is 2 bytes. Read more [here](https://www.postgresql.org/docs/9.5/static/datatype-numeric.html#DATATYPE-INT).

This is a potential issue because neither of those data types (**integer**, **bigint** or **smallint**) support data precision as an input when creating/altering the table. Hence, updating/migrating the model using the discovered model definition with those data precision values throws a syntax error.

This PR sets the **dataPrecision** field to `null` upon discovering model properties for properties which is of either integer, bigint or smallint.

fixes https://github.com/strongloop/loopback-connector-postgresql/issues/284