### PR TITLE
Allow migration on different schema

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -21,7 +21,8 @@ function mixinMigration(PostgreSQL) {
     var sql = 'SELECT column_name AS "column", data_type AS "type", ' +
     'is_nullable AS "nullable", character_maximum_length as "length"' // , data_default AS "Default"'
     + ' FROM "information_schema"."columns" WHERE table_name=\'' +
-    this.table(model) + '\'';
+    this.table(model) + '\' and table_schema=\'' +
+    this.schema(model) + '\'';
     this.execute(sql, function(err, fields) {
       if (err) {
         return cb(err);
@@ -46,11 +47,14 @@ function mixinMigration(PostgreSQL) {
           '  FROM generate_subscripts(ix.indoption, 1) AS k ' +
           '  ORDER BY k ' +
           ') AS "order" ' +
-          'FROM pg_class t, pg_class i, pg_index ix, pg_am am ' +
-          'WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND ' +
+          'FROM pg_class t, pg_class i, pg_index ix, pg_am am, ' +
+          'pg_namespace ns WHERE t.oid = ix.indrelid AND ' +
+          'i.oid = ix.indexrelid AND ' +
           'i.relam = am.oid AND ' +
           't.relkind=\'r\' AND t.relname=\'' +
-          this.table(model) + '\'';
+          this.table(model) + '\'' +
+          ' and (ns.oid = t.relnamespace and ns.nspname=\'' +
+          this.schema(model) + '\')';
     this.execute(sql, function(err, indexes) {
       if (err) {
         return cb(err);


### PR DESCRIPTION
### Description

If I have two models with the same name table name, I should be able to `autoupdate` those tables. Currently, `autoupdate` on such scenario fails. This PR fixes the sql statement to allow consideration of the schema before performing the update.

fixes https://github.com/strongloop/loopback-connector-postgresql/issues/287