### PR TITLE
Add test for transaction support in count()

### DIFF
--- a/test/postgresql.transaction.test.js
+++ b/test/postgresql.transaction.test.js
@@ -53,7 +53,13 @@ describe('transactions', function() {
         function(err, posts) {
           if (err) return done(err);
           posts.length.should.be.eql(count);
-          done();
+          // Make sure both find() and count() behave the same way
+          Post.count(where, options,
+            function(err, result) {
+              if (err) return done(err);
+              result.should.be.eql(count);
+              done();
+            });
         });
     };
   }


### PR DESCRIPTION
### Description

As outlined in https://github.com/strongloop/loopback-connector/pull/114:  When passing on a transaction object to connector.count(), it does not currently get passed on internally to the SQL `execute()` method, meaning that the count of the table outside the transaction will be counted and a wrong result will be returned.

#### Related issues

- https://github.com/strongloop/loopback-connector/pull/114

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
