### PR TITLE
Upgrade to pg@7.

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -50,38 +50,6 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 };
 
-// there is a bug in the generic pool where it will not recreate
-// destroyed workers (even if there is waiting work to do) unless
-// there is a min specified. Make sure we keep some connections
-// SEE: https://github.com/coopernurse/node-pool/pull/186
-// SEE: https://github.com/brianc/node-pg-pool/issues/48
-// SEE: https://github.com/strongloop/loopback-connector-postgresql/issues/231
-function _ensureMinimum() {
-  var i, diff, waiting;
-  if (this._draining) return;
-  waiting = this._waitingClients.size();
-  if (this._factory.min > 0) { // we have positive specified minimum
-    diff = this._factory.min - this._count;
-  } else if (waiting > 0) { // we have no minimum, but we do have work to do
-    diff = Math.min(waiting, this._factory.max - this._count);
-  }
-  for (i = 0; i < diff; i++) {
-    this._createResource();
-  }
-};
-function makePool(options) {
-  var pg = new postgresql.Pool(options);
-  // Monkey patch to ensure we always finish our work
-  //  - There is a bug where callbacks go uncalled if min is not set
-  //  - We might still not want a connection to *always* exist
-  //  - but we do want to create up to max connections if we have work
-  //  - still waiting
-  // This should be safe till the version of pg-pool is upgraded
-  // SEE: https://github.com/coopernurse/node-pool/pull/186
-  pg.pool._ensureMinimum = _ensureMinimum;
-  return pg;
-}
-
 /**
  * PostgreSQL connector constructor
  *
@@ -110,7 +78,7 @@ function PostgreSQL(postgresql, settings) {
     this.clientConfig.connectionString = settings.url;
   }
   this.clientConfig.Promise = Promise;
-  this.pg = makePool(this.clientConfig);
+  this.pg = new postgresql.Pool(this.clientConfig);
 
   this.settings = settings;
   debug('Settings %j', settings);

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -75,12 +75,7 @@ function mixinTransaction(PostgreSQL) {
       connection.autorelease(err);
       connection.autorelease = null;
     } else {
-      var pool = this.pg;
-      if (err) {
-        pool.pool.destroy(connection);
-      } else {
-        pool.pool.release(connection);
-      }
+      connection.release();
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bluebird": "^3.4.6",
     "debug": "^2.1.1",
     "loopback-connector": "^4.2.2",
-    "pg": "^6.0.0",
+    "pg": "^7.0.0",
     "strong-globalize": "^2.6.2",
     "uuid": "^3.0.1"
   },

--- a/test/postgresql.initialization.test.js
+++ b/test/postgresql.initialization.test.js
@@ -18,14 +18,14 @@ function newConfig(withURL) {
 describe('initialization', function() {
   it('honours user-defined pg-pool settings', function() {
     var dataSource = new DataSource(connector, newConfig());
-    var pool = dataSource.connector.pg.pool;
-    pool._factory.max.should.not.equal(999);
+    var pool = dataSource.connector.pg;
+    pool.options.max.should.not.equal(999);
 
     var settings = newConfig();
     settings.max = 999; // non-default value
     var dataSource = new DataSource(connector, settings);
-    var pool = dataSource.connector.pg.pool;
-    pool._factory.max.should.equal(999);
+    var pool = dataSource.connector.pg;
+    pool.options.max.should.equal(999);
   });
 
   it('honours user-defined url settings', function() {
@@ -45,8 +45,8 @@ describe('initialization', function() {
     var urlOnly = {url: newConfig(true).url, max: 999};
 
     var dataSource = new DataSource(connector, urlOnly);
-    var pool = dataSource.connector.pg.pool;
-    pool._factory.max.should.equal(999);
+    var pool = dataSource.connector.pg;
+    pool.options.max.should.equal(999);
 
     var clientConfig = dataSource.connector.clientConfig;
     clientConfig.connectionString.should.equal(urlOnly.url);
@@ -57,9 +57,8 @@ describe('postgresql connector errors', function() {
   it('Should complete these 4 queries without dying', function(done) {
     var dataSource = getDataSource();
     var db = dataSource.connector;
-    var pool = db.pg.pool;
-    pool._factory.max = 5;
-    pool._factory.min = null;
+    var pool = db.pg;
+    pool.options.max = 5;
     var errors = 0;
     var shouldGet = 0;
     function runErrorQuery() {


### PR DESCRIPTION
### Description

Earlier pool release hacks are no longer necessary in pg-pool@2.x.

#### Related issues

#197 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
