### PR TITLE
Upgrade to pg@7

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -68,12 +68,7 @@ function mixinTransaction(PostgreSQL) {
       connection.autorelease(err);
       connection.autorelease = null;
     } else {
-      var pool = this.pg;
-      if (err) {
-        pool.pool.destroy(connection);
-      } else {
-        pool.pool.release(connection);
-      }
+      connection.release();
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bluebird": "^3.4.6",
     "debug": "^2.1.1",
     "loopback-connector": "^2.1.0",
-    "pg": "^6.0.0",
+    "pg": "^7.0.0",
     "strong-globalize": "^2.6.2"
   },
   "devDependencies": {

--- a/test/postgresql.initialization.test.js
+++ b/test/postgresql.initialization.test.js
@@ -1,0 +1,70 @@
+'use strict';
+require('./init');
+var Promise = require('bluebird');
+var connector = require('..');
+var DataSource = require('loopback-datasource-juggler').DataSource;
+var should = require('should');
+
+// simple wrapper that uses JSON.parse(JSON.stringify()) as cheap clone
+function newConfig(withURL) {
+  return JSON.parse(JSON.stringify(getDBConfig(withURL)));
+}
+
+describe('initialization', function() {
+  it('honours user-defined pg-pool settings', function() {
+    var dataSource = new DataSource(connector, newConfig());
+    var pool = dataSource.connector.pg;
+    pool.options.max.should.not.equal(999);
+
+    var settings = newConfig();
+    settings.max = 999; // non-default value
+    var dataSource = new DataSource(connector, settings);
+    var pool = dataSource.connector.pg;
+    pool.options.max.should.equal(999);
+  });
+
+  it('honours user-defined url settings', function() {
+    var settings = newConfig();
+
+    var dataSource = new DataSource(connector, settings);
+    var clientConfig = dataSource.connector.clientConfig;
+    should.not.exist(clientConfig.connectionString);
+
+    settings = newConfig(true);
+    var dataSource = new DataSource(connector, settings);
+    var clientConfig = dataSource.connector.clientConfig;
+    clientConfig.connectionString.should.equal(settings.url);
+  });
+});
+
+describe('postgresql connector errors', function() {
+  it('Should complete these 4 queries without dying', function(done) {
+    var dataSource = getDataSource();
+    var db = dataSource.connector;
+    var pool = db.pg;
+    pool.options.max = 5;
+    var errors = 0;
+    var shouldGet = 0;
+    function runErrorQuery() {
+      shouldGet++;
+      return new Promise(function(resolve, reject) {
+        db.executeSQL("SELECT 'asd'+1 ", [], {}, function(err, res) {
+          if (err) {
+            errors++;
+            resolve(err);
+          } else {
+            reject(res); // this should always error
+          }
+        });
+      });
+    };
+    var ps = [];
+    for (var i = 0; i < 12; i++) {
+      ps.push(runErrorQuery());
+    }
+    Promise.all(ps).then(function() {
+      shouldGet.should.equal(errors);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Description
Hello,

In this PR, we upgrade to pg@7 as it has been done on version 3.x
This fixes #311. (When a DB fail over, server goes down until restart)

#### Related issues
- connect to #311 
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x ] New tests added or existing tests modified to cover all changes
- [ x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
