### PR TITLE
Autoupdate in series instead of concurrently.

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -93,7 +93,7 @@ function mixinMigration(PostgreSQL) {
 
     models = models || Object.keys(this._models);
 
-    async.each(models, function(model, done) {
+    async.eachSeries(models, function(model, done) {
       if (!(model in self._models)) {
         return process.nextTick(function() {
           done(new Error(g.f('Model not found: %s' + model)));
@@ -129,7 +129,7 @@ function mixinMigration(PostgreSQL) {
     models = models || Object.keys(this._models);
 
     var changes = [];
-    async.each(models, function(model, done) {
+    async.eachSeries(models, function(model, done) {
       self.getTableStatus(model, function(err, fields) {
         changes = changes.concat(self.getAddModifyColumns(model, fields));
         changes = changes.concat(self.getDropColumns(model, fields));


### PR DESCRIPTION
I've been seeing this error in a project I've been working on sometimes:

`duplicate key value violates unique constraint "pg_namespace_nspname_index"`

A quick search leads to this Stack Overflow answer: https://stackoverflow.com/a/29908840

The answer recommends that DDLs not be done concurrently. I think I've been seeing this error because I have a couple of models in a schema other than `public`, and autoupdate is attempting to create the same schema concurrently.

This commit simply switches out `async.each` for `async.eachSeries`, so each DDL is allowed to finish before the next one runs.