### PR TITLE
Added fix to support regexp for nested query param

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -645,6 +645,11 @@ PostgreSQL.prototype.toColumnValue = function(prop, val) {
       return null;
     }
   }
+
+  if(typeof val == "object" && val instanceof String) {
+    val += "";
+  }
+  
   if (prop.type === String) {
     return String(val);
   }

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -580,6 +580,16 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
       } else if (operator === 'regexp' && expression instanceof RegExp) {
         // do not coerce RegExp based on property definitions
         columnValue = expression;
+      } else if (operator === 'regexp' && !(expression instanceof RegExp)) {
+
+        if(expression.startsWith('/')) {
+          var lastSlash = expression.lastIndexOf("/");
+          expression = new RegExp(expression.slice(1, lastSlash), expression.slice(lastSlash + 1));
+        } else {
+          expression = new RegExp(expression);
+        }
+
+        columnValue = expression;
       } else {
         columnValue = this.toColumnValue(p, expression);
       }


### PR DESCRIPTION
### Description
`
GET /path/to/api/model
filter={
    "param.subparam": {
        "regexp": "^keyword"
    }
}
`
Generated SQL params ends up being:
`
[undefined]
`

I have added a regexp parser so generated sql params would be:
`
['^keyword']
`

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
