### PR TITLE
add support for UPDATE RETURNING

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -140,6 +140,10 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
           case 'DELETE':
           case 'UPDATE':
             result = {affectedRows: data.rowCount, count: data.rowCount};
+
+            if(data.rows)
+              result.rows = data.rows;
+
             break;
           default:
             result = data.rows;

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -172,6 +172,22 @@ describe('postgresql connector', function() {
       });
   });
 
+  it('should support `rows` if RETURNING used after UPDATE', function(done) {
+    Post.create(
+      {title: 'rows returned from update', content: 'Content'},
+      function(err, p) {
+        if (err) return done(err);
+        post = p;
+        var query = "UPDATE PostWithBoolean SET title ='something else' WHERE id=" + post.id + " RETURNING id";
+        db.connector.execute(query, function(err, results) {
+          results.should.have.property('count', 1);
+          results.should.have.property('affectedRows', 1);
+          results.rows[0].id.should.eql(post.id);
+          done(err);
+        });
+      });
+  });
+
   it('should support updating boolean types with false value', function(done) {
     Post.update({id: post.id}, {approved: false}, function(err) {
       should.not.exists(err);


### PR DESCRIPTION
### Support UPDATE ... RETURNING

Adds `rows` from pg driver after an UPDATE if RETURNING specified

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
