### PR TITLE
added possibility to add a file path to seek password

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -16,6 +16,7 @@ var util = require('util');
 var debug = require('debug')('loopback:connector:postgresql');
 var debugData = require('debug')('loopback:connector:postgresql:data');
 var Promise = require('bluebird');
+var fs = require('fs');
 
 /**
  *
@@ -34,6 +35,9 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   var dbSettings = dataSource.settings || {};
   dbSettings.host = dbSettings.host || dbSettings.hostname || 'localhost';
   dbSettings.user = dbSettings.user || dbSettings.username;
+  if (dbSettings.passwordFile){
+      dbSettings.password = fs.readFileSync(dbSettings.passwordFile);
+  }
 
   dataSource.connector = new PostgreSQL(postgresql, dbSettings);
   dataSource.connector.dataSource = dataSource;


### PR DESCRIPTION
### Description
Added the ability to add a "passwordFile" field to the datasources.json to allow to store the password into a file.
This can be done programatically but doing so will break the use of the loopback cli utility (the cli utility only pick datasources available in datasources.json)
For example this can be usefull when using docker secret as storing secret in environnement may be judged insecure see moby/moby#30866

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
