### PR TITLE
Unaccent functionality for regex comparation

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -149,6 +149,11 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
     });
   }
 
+  function checkUnaccent(connection, cb) {
+    var _test = 'select unaccent(\'test\')';
+    connection.query(_test, null, cb);
+  }
+
   var transaction = options.transaction;
   if (transaction && transaction.connector === this) {
     if (!transaction.connection) {
@@ -167,7 +172,17 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   } else {
     self.pg.connect(function(err, connection, done) {
       if (err) return callback(err);
-      executeWithConnection(connection, done);
+      if (options.unaccent && options.queryType) {
+        checkUnaccent(connection, function (err, data) {
+          if (err) {
+            if (err.code == 42883) console.log('No unaccent function enabled on PG schema. Enable to ignore accentuation.');
+            else console.log(err);
+          }
+          else sql = unaccent(sql, options.queryType);
+          executeWithConnection(connection, done);
+        });
+      }
+      else executeWithConnection(connection, done);
     });
   }
 };
@@ -319,6 +334,34 @@ function escapeLiteral(str) {
     escaped = ' E' + escaped;
   }
   return escaped;
+}
+
+function unaccent(sql, queryType) {
+  // Check LIKE (~*) & SELECT from query and add unaccent custom query
+  if (sql.indexOf("~*") !== -1 && sql.indexOf(queryType) !== -1) {
+    // Split from ~*
+    var _sql = sql.split(" ~* ");
+    // Split left side from WHERE or (
+    var _sqlLeft = [];
+    var leftType = "";
+    if (_sql[0].indexOf("(") !== -1) {
+      _sqlLeft = _sql[0].split("(");
+      leftType = "(";
+    }
+    else _sqlLeft = _sql[0].split("WHERE ");
+
+    // Split right side from AND or ORDER
+    var _sqlRight = [];
+    var rightType = " AND \"";
+    if (_sql[1].indexOf(" AND \"") !== -1) _sqlRight = _sql[1].split(" AND \"");
+    else {
+      _sqlRight = _sql[1].split(" ORDER BY ");
+      rightType = " ORDER BY ";
+    }
+    // Merge sql splits
+    return _sqlLeft[0] + leftType + 'unaccent(' + _sqlLeft[1] + ') ~* unaccent(' + _sqlRight[0] + ')' + rightType + _sqlRight[1];
+  }
+  else return sql;
 }
 
 /*


### PR DESCRIPTION
### Description

This feature will enable to receive incoming SQL statement execution requests and use unaccent function in regex cases (~* operator). It receives in _PostgreSQL.prototype.executeSQL_ method the options from DAO cases (eg. find), and checks if unaccent function is enabled in the PG schema. If that's the case, convert the SQL with a regex comparation with the unaccent function, using split to adjust the original SQL string.

Check if unaccent function is enabled
```js
function checkUnaccent(connection, cb) {
    var _test = 'select unaccent(\'test\')';
    connection.query(_test, null, cb);
}
```

Main logic
```js
self.pg.connect(function(err, connection, done) {
      if (err) return callback(err);
      if (options.unaccent && options.queryType) {
        checkUnaccent(connection, function (err, data) {
          if (err) {
            if (err.code == 42883) console.log('No unaccent function enabled on PG schema. Enable to ignore accentuation.');
            else console.log(err);
          }
          else sql = unaccent(sql, options.queryType);
          executeWithConnection(connection, done);
        });
      }
      else executeWithConnection(connection, done);
});
```

Unaccent function with splits
```js
function unaccent(sql, queryType) {
    // Check LIKE (~*) & SELECT from query and add unaccent custom query
    if (sql.indexOf("~*") !== -1 && sql.indexOf(queryType) !== -1) {
      // Split from ~*
      var _sql = sql.split(" ~* ");
      // Split left side from WHERE or (
      var _sqlLeft = [];
      var leftType = "";
      if (_sql[0].indexOf("(") !== -1) {
        _sqlLeft = _sql[0].split("(");
        leftType = "(";
      }
      else _sqlLeft = _sql[0].split("WHERE ");

      // Split right side from AND or ORDER
      var _sqlRight = [];
      var rightType = " AND \"";
      if (_sql[1].indexOf(" AND \"") !== -1) _sqlRight = _sql[1].split(" AND \"");
      else {
        _sqlRight = _sql[1].split(" ORDER BY ");
        rightType = " ORDER BY ";
      }
      // Merge sql splits
      return _sqlLeft[0] + leftType + 'unaccent(' + _sqlLeft[1] + ') ~* unaccent(' + _sqlRight[0] + ')' + rightType + _sqlRight[1];
    }
    else return sql;
}
```

<!-- #### Related issues -->

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
- connect to <link_to_referenced_issue>
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
### Description

This feature will enable to receive incoming SQL statement execution requests and use unaccent function in regex cases (~* operator). It receives in _PostgreSQL.prototype.executeSQL_ method the options from DAO cases (eg. find), and checks if unaccent function is enabled in the PG schema. If that's the case, convert the SQL with a regex comparation with the unaccent function, using split to adjust the original SQL string.

Check if unaccent function is enabled
```js
function checkUnaccent(connection, cb) {
    var _test = 'select unaccent(\'test\')';
    connection.query(_test, null, cb);
}
```

Main logic
```js
self.pg.connect(function(err, connection, done) {
      if (err) return callback(err);
      if (options.unaccent && options.queryType) {
        checkUnaccent(connection, function (err, data) {
          if (err) {
            if (err.code == 42883) console.log('No unaccent function enabled on PG schema. Enable to ignore accentuation.');
            else console.log(err);
          }
          else sql = unaccent(sql, options.queryType);
          executeWithConnection(connection, done);
        });
      }
      else executeWithConnection(connection, done);
});
```

Unaccent function with splits
```js
function unaccent(sql, queryType) {
    // Check LIKE (~*) & SELECT from query and add unaccent custom query
    if (sql.indexOf("~*") !== -1 && sql.indexOf(queryType) !== -1) {
      // Split from ~*
      var _sql = sql.split(" ~* ");
      // Split left side from WHERE or (
      var _sqlLeft = [];
      var leftType = "";
      if (_sql[0].indexOf("(") !== -1) {
        _sqlLeft = _sql[0].split("(");
        leftType = "(";
      }
      else _sqlLeft = _sql[0].split("WHERE ");

      // Split right side from AND or ORDER
      var _sqlRight = [];
      var rightType = " AND \"";
      if (_sql[1].indexOf(" AND \"") !== -1) _sqlRight = _sql[1].split(" AND \"");
      else {
        _sqlRight = _sql[1].split(" ORDER BY ");
        rightType = " ORDER BY ";
      }
      // Merge sql splits
      return _sqlLeft[0] + leftType + 'unaccent(' + _sqlLeft[1] + ') ~* unaccent(' + _sqlRight[0] + ')' + rightType + _sqlRight[1];
    }
    else return sql;
}
```

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
- connect to <link_to_referenced_issue>
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
