### PR TITLE
stop execution if rollback is called

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -67,6 +67,12 @@ function mixinTransaction(PostgreSQL) {
       self.releaseConnection(connection, err);
       cb(err);
     });
+    //If we don't set txId to null and wait for the callback
+    //of ROLLBACK query to execute, another query can be executed in the
+    //same transaction because the callback will be called asynchronously
+    if (typeof connection.autorelease === 'function') {
+      connection.txId = null;
+    }
   };
 
   PostgreSQL.prototype.releaseConnection = function(connection, err) {


### PR DESCRIPTION
### Description
This fixes the issue described in #230 

#### Related issues
#129

Refer to rollback function in https://github.com/zbarbuto/loopback-connector-postgresql/blob/1361460cea86fadd14a68aa8fe9c55f14ecb9a6d/lib/transaction.js#L58-L86

After the `ROLLBACK` is executed, callback will be sent to the event loop to be executed. Event loop can pick any of the available callbacks to execute. It can pick another function that can do database calls in the same transaction and because releaseConnection has not been called, the statement will execute.
To stop the execution,`connection.txId` should be set to null without waiting for the callback of `ROLLBACK` to be called