### PR TITLE
Adds support for INSERT RETURNING

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -138,6 +138,7 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
       if (data) {
         switch (data.command) {
           case 'DELETE':
+          case 'INSERT':
           case 'UPDATE':
             result = {affectedRows: data.rowCount, count: data.rowCount};
 

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -188,6 +188,21 @@ describe('postgresql connector', function() {
       });
   });
 
+  it('should support `rows` if RETURNING used after INSERT', function(done) {
+    var query = 'INSERT PostWithBoolean (title) VALUES(\'fresh\') RETURNING id';
+    db.connector.execute(query, function(err, results) {
+      results.should.have.property('count', 1);
+      results.should.have.property('affectedRows', 1);
+
+      var postId = results.rows[0].id;
+
+      Post.findById(postId, function(err, p) {
+        p.should.have.property('id', postId);
+        done(err);
+      });
+    });
+  });
+
   it('should support updating boolean types with false value', function(done) {
     Post.update({id: post.id}, {approved: false}, function(err) {
       should.not.exists(err);


### PR DESCRIPTION
### Description

Adds support to fetch rows from INSERT with a RETURNING clause.  Since the behavior is the same as UPDATE RETURNING, I wanted to see if I could get away with 

#### Related issues

Identical in behavior to PR #318.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
