### PR TITLE
Export table comments in description field

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -149,6 +149,11 @@ function mixinDiscovery(PostgreSQL) {
             || r.dataType === 'smallint')
             r.dataPrecision = null;
           r.type = self.buildPropertyType(r, options);
+
+          if (r.columnComment) {
+            r.postgresql = {description: r.columnComment};
+          }
+
           self.setNullableProperty(r);
         });
         cb(err, results);
@@ -168,8 +173,10 @@ function mixinDiscovery(PostgreSQL) {
     if (owner) {
       sql = this.paginateSQL('SELECT table_schema AS "owner", table_name AS "tableName", column_name AS "columnName",'
           + 'data_type AS "dataType", character_maximum_length AS "dataLength", numeric_precision AS "dataPrecision",'
-          + ' numeric_scale AS "dataScale", is_nullable AS "nullable"'
+          + ' numeric_scale AS "dataScale", is_nullable AS "nullable",'
+          + ' pg_catalog.col_description(cls.oid, ordinal_position::int) AS "columnComment"'
           + ' FROM information_schema.columns'
+          + ' JOIN pg_catalog.pg_class cls ON cls.relname = table_name'
           + ' WHERE table_schema=\'' + owner + '\''
           + (table ? ' AND table_name=\'' + table + '\'' : ''),
         'table_name, ordinal_position', {});
@@ -177,8 +184,10 @@ function mixinDiscovery(PostgreSQL) {
       sql = this.paginateSQL('SELECT current_schema() AS "owner", table_name AS "tableName",'
           + ' column_name AS "columnName",'
           + ' data_type AS "dataType", character_maximum_length AS "dataLength", numeric_precision AS "dataPrecision",'
-          + ' numeric_scale AS "dataScale", is_nullable AS "nullable"'
+          + ' numeric_scale AS "dataScale", is_nullable AS "nullable",'
+          + ' pg_catalog.col_description(cls.oid, ordinal_position::int) AS "columnComment"'
           + ' FROM information_schema.columns'
+          + ' JOIN pg_catalog.pg_class cls ON cls.relname = table_name'
           + (table ? ' WHERE table_name=\'' + table + '\'' : ''),
         'table_name, ordinal_position', {});
     }

--- a/test/postgresql.discover.test.js
+++ b/test/postgresql.discover.test.js
@@ -339,4 +339,14 @@ describe('Discover and build models', function() {
       });
     });
   });
+
+  it('should build a model from discovery with comments', function(done) {
+    db.discoverAndBuildModels('TestGeo', {schema: 'public'}, function(err, schema) {
+      var prop = schema.Testgeo.definition.properties.loc.postgresql;
+      assert(prop);
+      assert.equal(prop.description, 'The location of property of TestGeo');
+      done();
+    });
+  });
 });
+

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -56,6 +56,9 @@ CREATE TABLE "TestGeo" (
     id integer NOT NULL
 );
 
+COMMENT ON TABLE "TestGeo" IS 'The TestGeo table';
+COMMENT ON COLUMN "TestGeo".loc IS 'The location of property of TestGeo';
+
 
 --
 -- Name: TestGeo_id_seq; Type: SEQUENCE; Schema: public; Owner: strongloop


### PR DESCRIPTION
### Description
This patch exports comments on columns as descriptions in the models. To be used for spec generation downstream.

#### Related issues
- none

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
