### PR TITLE
Type 'double precision' mapped to String

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -342,6 +342,7 @@ function mixinDiscovery(PostgreSQL) {
       case 'NUMERIC':
       case 'REAL':
       case 'DOUBLE PRECISION':
+      case 'FLOAT':
       case 'SERIAL':
       case 'BIGSERIAL':
         return 'Number';


### PR DESCRIPTION
On line 144, dataType "real" and "double precision" are changed to "float", but buildPropertyType has no case for "FLOAT":
https://github.com/strongloop/loopback-connector-postgresql/blob/master/lib/discovery.js#L144

This change simply adds a case statement for 'FLOAT'