### PR TITLE
Added full text search operation using to_tsvector and ts_query

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -438,6 +438,16 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
       var regexOperator = operatorValue.ignoreCase ? ' ~* ?' : ' ~ ?';
       return new ParameterizedSQL(columnName + regexOperator,
           [operatorValue.source]);
+    case 'fullTextSearch':
+      let tsVector = propertyDefinition.postgresql.tsVector
+      if (tsVector === undefined) {
+        g.warn('{{PostgreSQL}} fullTextSearch defaulting to `english`, set `postgresql.tsVector` to change')
+        tsVector = 'english'
+      }
+
+      return new ParameterizedSQL(
+        "to_tsvector('" + tsVector + "', " + columnName + "::TEXT) @@ plainto_tsquery('" + tsVector + "', ?)",
+        [operatorValue]);
     default:
       // invoke the base implementation of `buildExpression`
       return this.invokeSuper('buildExpression', columnName, operator,
@@ -583,6 +593,8 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
         }
       } else if (operator === 'regexp' && expression instanceof RegExp) {
         // do not coerce RegExp based on property definitions
+        columnValue = expression;
+      } else if (operator === 'fullTextSearch') {
         columnValue = expression;
       } else {
         columnValue = this.toColumnValue(p, expression);

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -753,6 +753,20 @@ describe('postgresql connector', function() {
         });
       });
     });
+
+    it('allows full text search of nested json properties', function(done) {
+      Customer.find({
+        where: {
+          'address': {
+            fullTextSearch: 'Springfield'
+          }
+        },
+      }, function(err, results1) {
+        if (err) return done(err);
+        results1[0].address.city.should.eql('Springfield');
+        done();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Description
Pull request adding basic implementation of full text search operation support using PostgreSQL backend. I'm hoping to prompt discussion, is this something we would want? Might we want to rename the operator? What am I missing to make this future proof?

#### Related issues

- strongloop/loopback-connector-mysql/issues/350

### Checklist

- [ ] Have received feedback
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)