### PR TITLE
Fix timestamp precision force isActual to false

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -19,6 +19,7 @@ function mixinMigration(PostgreSQL) {
 
   PostgreSQL.prototype.showFields = function(model, cb) {
     var sql = 'SELECT column_name AS "column", data_type AS "type", ' +
+    'datetime_precision AS time_precision, ' +
     'is_nullable AS "nullable", character_maximum_length as "length"' // , data_default AS "Default"'
     + ' FROM "information_schema"."columns" WHERE table_name=\'' +
     this.table(model) + '\' and table_schema=\'' +
@@ -28,7 +29,7 @@ function mixinMigration(PostgreSQL) {
         return cb(err);
       } else {
         fields.forEach(function(field) {
-          field.type = mapPostgreSQLDatatypes(field.type, field.length);
+          field.type = mapPostgreSQLDatatypes(field.type, field.length, field.time_precision);
         });
         cb(err, fields);
       }
@@ -412,8 +413,30 @@ function mixinMigration(PostgreSQL) {
     // i.e dataLength, dataPrecision, dataScale
     // https://loopback.io/doc/en/lb3/Model-definition-JSON-file.html
     if (colType) {
+      if (colType === 'CHARACTER VARYING') return  'VARCHAR(' + colLength + ')';
       if (colLength) return colType + '(' + colLength + ')';
       if (colPrecision && colScale) return colType + '(' + colPrecision + ',' + colScale + ')';
+      if (colType.startsWith('TIME')) {
+        var strPrecision = '';
+        if (colPrecision < 6) { // default is 6
+          strPrecision = '(' + colPrecision + ') ';
+        }
+        switch (colType) {
+          case 'TIMESTAMP':
+          case 'TIMESTAMP WITHOUT TIME ZONE':
+            return 'TIMESTAMP ' + strPrecision + 'WITHOUT TIME ZONE';
+          case 'TIMESTAMPTZ':
+          case 'TIMESTAMP WITH TIME ZONE':
+            return 'TIMESTAMP ' + strPrecision + 'WITH TIME ZONE';
+          case 'TIME':
+          case 'TIME WITHOUT TIME ZONE':
+            return 'TIME ' + strPrecision + 'WITHOUT TIME ZONE';
+          case 'TIME WITH TIME ZONE':
+            return 'TIME ' + strPrecision + 'WITH TIME ZONE';
+          default:
+            return colType + ' (' + colPrecision + ')';
+        }
+      }
       if (colPrecision) return colType + '(' + colPrecision + ')';
       return colType;
     }
@@ -516,11 +539,26 @@ function mixinMigration(PostgreSQL) {
     }
   }
 
-  function mapPostgreSQLDatatypes(typeName, typeLength) {
-    if (typeName.toUpperCase() === 'CHARACTER VARYING' || typeName.toUpperCase() === 'VARCHAR') {
-      return typeLength ? 'VARCHAR(' + typeLength + ')' : 'VARCHAR(1024)';
-    } else {
-      return typeName;
+  function mapPostgreSQLDatatypes(typeName, typeLength, typeTimePrecision) {
+    var type = typeName.toUpperCase();
+    var strPrecision = '';
+    if (typeTimePrecision < 6) { // default is 6
+      strPrecision = '(' + typeTimePrecision + ') ';
+    }
+    switch (type) {
+      case 'CHARACTER VARYING':
+      case 'VARCHAR':
+        return typeLength ? 'VARCHAR(' + typeLength + ')' : 'VARCHAR(1024)';
+      case 'TIMESTAMP WITHOUT TIME ZONE':
+        return 'TIMESTAMP ' + strPrecision + 'WITHOUT TIME ZONE';
+      case 'TIMESTAMP WITH TIME ZONE':
+        return 'TIMESTAMP ' + strPrecision + 'WITH TIME ZONE';
+      case 'TIME WITHOUT TIME ZONE':
+        return 'TIME ' + strPrecision + 'WITHOUT TIME ZONE';
+      case 'TIME WITH TIME ZONE':
+        return 'TIME ' + strPrecision + 'WITH TIME ZONE';
+      default:
+        return typeName;
     }
   }
 

--- a/test/postgresql.timestamp.test.js
+++ b/test/postgresql.timestamp.test.js
@@ -1,0 +1,70 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-connector-postgresql
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+var should = require('should');
+var db, PostWithTimestamps;
+
+describe('Timestamps', function() {
+  describe('type and precision', function() {
+    before(function() {
+      db = getDataSource();
+
+      PostWithTimestamps = db.define('PostWithTimestamps', {
+        timestampDefault: {
+          type: 'Date',
+          postgresql: {
+            dbDefault: 'now()',
+          },
+        },
+        timestampWithType: {
+          type: 'Date',
+          postgresql: {
+            dataType: 'TIMESTAMP WITH TIME ZONE',
+            dbDefault: 'now()',
+          },
+        },
+        timestampWithPrecision: {
+          type: 'Date',
+          postgresql: {
+            dataType: 'TIMESTAMP WITH TIME ZONE',
+            dataPrecision: 3,
+            dbDefault: 'now()',
+          },
+        },
+        timestampFromJs: {
+          type: 'Date',
+          postgresql: {
+            dataType: 'TIMESTAMP WITH TIME ZONE',
+            dataPrecision: 3,
+          },
+        },
+      });
+    });
+
+    it('should run migration', function(done) {
+      db.automigrate('PostWithTimestamps', function() {
+        done();
+      });
+    });
+
+    it('create instance', function(done) {
+      PostWithTimestamps.create(
+        {timestampFromJs: new Date()}, function(err, p) {
+          should.not.exist(err);
+          should.exist(p);
+          done();
+        });
+    });
+
+    it('isActual() should return true', function(done) {
+      db.isActual(['PostWithTimestamps'], function(err, ok) {
+        if (err) return done(err);
+        ok.should.equal(true);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description
Hello,
If timestamp precision is set, e.g.:
```
"modified": {
  "type": "date",
  "postgresql": {
    "dataType": "timestamp (3) with time zone"
  }
}
```
when isActual() is called always return `false` (because `datatypeChanged(propName, oldSettings)` will return `true`). The `"dataPrecision"` property is ignored with Date types.
So, with this fix you can use `"dataPrecision"` to set the precision of a PostgreSQL date to match JavaScript (milliseconds instead of microseconds) without isActual() triggering auto-updates without a reason.
```
"modified": {
  "type": "date",
  "postgresql": {
    "dataType": "timestamp with time zone",
    "dataPrecision": 3
  }
}
```

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
