### PR TITLE
feat: add support for create and delete foreign key constraint from model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .project
 .idea
+.vscode
 coverage
 lib-cov
 *.seed

--- a/README.md
+++ b/README.md
@@ -430,6 +430,66 @@ The auto-migrate method:
 
 Destroying models may result in errors due to foreign key integrity. First delete any related models by calling delete on models with relationships.
 
+### Auto-migrate/Auto-update models with foreign keys
+
+Foreign key constraints can be defined in the model `options`. Removing or updating the value of `foreignKeys` will be updated or delete or update the constraints in the db tables.
+
+If there is a reference to an object being deleted then the `DELETE` will fail. Likewise if there is a create with an invalid FK id then the `POST` will fail.
+
+**Note**: The order of table creation is important. A referenced table must exist before creating a foreign key constraint.
+
+```json
+{
+  "name": "Customer",
+  "options": {
+    "idInjection": false
+  },
+  "properties": {
+    "id": {
+      "type": "String",
+      "length": 20,
+      "id": 1
+    },
+    "name": {
+      "type": "String",
+      "required": false,
+      "length": 40
+    }
+  }
+},
+
+{
+  "name": "Order",
+  "options": {
+    "idInjection": false,
+    "foreignKeys": {
+      "fk_order_customerId": {
+        "name": "fk_order_customerId",
+        "entity": "Customer",
+        "entityKey": "id",
+        "foreignKey": "customerId"
+      }
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "String",
+      "length": 20,
+      "id": 1
+    },
+    "customerId": {
+      "type": "String",
+      "length": 20
+    },
+    "description": {
+      "type": "String",
+      "required": false,
+      "length": 40
+    }
+  }
+}
+```
+
 ## Running tests
 
 ### Own instance

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -7,6 +7,7 @@
 var SG = require('strong-globalize');
 var g = SG();
 var async = require('async');
+var debug = require('debug')('loopback:connector:postgresql:migration');
 
 module.exports = mixinMigration;
 
@@ -83,7 +84,7 @@ function mixinMigration(PostgreSQL) {
 
     var applyPending = function(actions, cb, err, result) {
       var action = actions.shift();
-      var pendingChanges = action && action.call(self, model, actualFields) || [];
+      var pendingChanges = action && action() || [];
       if (pendingChanges.length) {
         self.applySqlChanges(model, pendingChanges, function(err, result) {
           if (!err) {
@@ -99,15 +100,37 @@ function mixinMigration(PostgreSQL) {
       }
     };
 
-    async.series([
-      function(cb) {
-        applyPending([self.getAddModifyColumns, self.getDropColumns], cb);
-      },
-      function(cb) {
-        self.addIndexes(model, actualIndexes, cb);
-      },
-    ], function(err, result) {
-      cb(err, result[0]);
+    self.discoverForeignKeys(self.table(model), {}, function(err, actualFks) {
+      if (err) {
+        debug('Failed to discover "%s" foreign keys %s', self.table(model), err);
+        cb(err);
+        return;
+      }
+
+      // actualFks is a list of EXISTING fkeys here,
+      // so you don't need to recreate them again
+      // prepare fkSQL for new foreign keys
+      var fkSQL = self.getForeignKeySQL(model,
+        self.getModelDefinition(model).settings.foreignKeys,
+        actualFks);
+
+      async.series([
+        function(cb) {
+          applyPending([
+            self.getAddModifyColumns.bind(self, model, actualFields),
+            self.getDropColumns.bind(self, model, actualFields),
+            self.getDropForeignKeys.bind(self, model, actualFks),
+          ], cb);
+        },
+        function(cb) {
+          self.addIndexes(model, actualIndexes, cb);
+        },
+        function(cb) {
+          self.addForeignKeys(model, fkSQL, cb);
+        },
+      ], function(err, result) {
+        cb(err, result[0]);
+      });
     });
   };
 
@@ -302,7 +325,14 @@ function mixinMigration(PostgreSQL) {
             if (err) {
               return cb(err, info);
             }
-            self.addIndexes(model, undefined, cb);
+            self.addIndexes(model, undefined, function(err) {
+              if (err) {
+                return cb(err);
+              }
+              self.addForeignKeys(model, function(err, result) {
+                cb(err);
+              });
+            });
           }
         );
       });
@@ -441,6 +471,112 @@ function mixinMigration(PostgreSQL) {
       case 'Boolean':
         return 'BOOLEAN'; // PostgreSQL doesn't have built-in boolean
     }
+  };
+
+  PostgreSQL.prototype.addForeignKeys = function(model, fkSQL, cb) {
+    var self = this;
+    var m = this.getModelDefinition(model);
+
+    if ((!cb) && ('function' === typeof fkSQL)) {
+      cb = fkSQL;
+      fkSQL = undefined;
+    }
+
+    if (!fkSQL || fkSQL.length === 0) {
+      var newFks = m.settings.foreignKeys;
+      if (newFks)
+        fkSQL = self.getForeignKeySQL(model, newFks);
+    }
+
+    if (fkSQL && fkSQL.length) {
+      self.applySqlChanges(model, [fkSQL.toString()], function(err, result) {
+        if (err) cb(err);
+        else
+          cb(null, result);
+      });
+    } else cb(null, {});
+  };
+
+  PostgreSQL.prototype.getDropForeignKeys = function(model, actualFks) {
+    var self = this;
+    var m = this.getModelDefinition(model);
+
+    var fks = actualFks;
+    var sql = [];
+    var correctFks = m.settings.foreignKeys || {};
+
+    // drop foreign keys for removed fields
+    if (fks && fks.length) {
+      var removedFks = [];
+      fks.forEach(function(fk) {
+        var needsToDrop = false;
+        var newFk = correctFks[fk.fkName];
+        if (newFk) {
+          var fkCol = newFk.foreignKey;
+          var fkRefKey = newFk.entityKey;
+          var fkEntityName = (typeof newFk.entity === 'object') ? newFk.entity.name : newFk.entity;
+          var fkRefTable = self.table(fkEntityName);
+          needsToDrop = fkCol != fk.fkColumnName ||
+                        fkRefKey != fk.pkColumnName ||
+                        fkRefTable != fk.pkTableName;
+        } else {
+          needsToDrop = true;
+        }
+
+        if (needsToDrop) {
+          sql.push('DROP CONSTRAINT ' + self.escapeName(fk.fkName));
+          removedFks.push(fk); // keep track that we removed these
+        }
+      });
+
+      // update out list of existing keys by removing dropped keys
+      removedFks.forEach(function(k) {
+        var index = actualFks.indexOf(k);
+        if (index !== -1) actualFks.splice(index, 1);
+      });
+    }
+    return sql;
+  };
+
+  PostgreSQL.prototype.getForeignKeySQL = function getForeignKeySQL(model, actualFks, existingFks) {
+    var self = this;
+    var addFksSql = [];
+    existingFks = existingFks || [];
+
+    if (actualFks) {
+      var keys = Object.keys(actualFks);
+      for (var i = 0; i < keys.length; i++) {
+        // all existing fks are already checked in PostgreSQL.prototype.dropForeignKeys
+        // so we need check only names - skip if found
+        if (existingFks.filter(function(fk) {
+          return fk.fkName === keys[i];
+        }).length > 0) continue;
+        var constraint = self.buildForeignKeyDefinition(model, keys[i]);
+
+        if (constraint) {
+          addFksSql.push('ADD ' + constraint);
+        }
+      }
+    }
+    return addFksSql;
+  };
+
+  PostgreSQL.prototype.buildForeignKeyDefinition = function buildForeignKeyDefinition(model, keyName) {
+    var definition = this.getModelDefinition(model);
+
+    var fk = definition.settings.foreignKeys[keyName];
+    if (fk) {
+      // get the definition of the referenced object
+      var fkEntityName = (typeof fk.entity === 'object') ? fk.entity.name : fk.entity;
+
+      // verify that the other model in the same DB
+      if (this._models[fkEntityName]) {
+        return 'CONSTRAINT ' + this.escapeName(fk.name) + ' ' +
+          'FOREIGN KEY (' + fk.foreignKey + ') ' +
+          'REFERENCES ' + this.tableEscaped(fkEntityName) + '(' + fk.entityKey + ')';
+      }
+    }
+    return '';
   };
 
   /*!

--- a/test/postgresql.autoupdate.test.js
+++ b/test/postgresql.autoupdate.test.js
@@ -361,4 +361,243 @@ describe('autoupdate', function() {
       });
     });
   });
+
+  describe('foreign key constraint', function() {
+    it('should create, update, and delete foreign keys', function(done) {
+      var customer2_schema = {
+        'name': 'CustomerTest2',
+        'options': {
+          'idInjection': false,
+          'postgresql': {
+            'schema': 'myapp_test',
+            'table': 'customer_test2',
+          },
+        },
+        'properties': {
+          'id': {
+            'type': 'String',
+            'length': 20,
+            'id': 1,
+          },
+          'name': {
+            'type': 'String',
+            'required': false,
+            'length': 40,
+          },
+          'email': {
+            'type': 'String',
+            'required': true,
+            'length': 40,
+          },
+          'age': {
+            'type': 'Number',
+            'required': false,
+          },
+        },
+      };
+
+      var customer3_schema = {
+        'name': 'CustomerTest3',
+        'options': {
+          'idInjection': false,
+          'postgresql': {
+            'schema': 'myapp_test',
+            'table': 'customer_test3',
+          },
+        },
+        'properties': {
+          'id': {
+            'type': 'String',
+            'length': 20,
+            'id': 1,
+          },
+          'name': {
+            'type': 'String',
+            'required': false,
+            'length': 40,
+          },
+          'email': {
+            'type': 'String',
+            'required': true,
+            'length': 40,
+          },
+          'age': {
+            'type': 'Number',
+            'required': false,
+          },
+        },
+      };
+
+      var orderTest_schema_v1 = {
+        'name': 'OrderTest',
+        'options': {
+          'idInjection': false,
+          'postgresql': {
+            'schema': 'myapp_test',
+            'table': 'order_test',
+          },
+          'foreignKeys': {
+            'fk_ordertest_customerId': {
+              'name': 'fk_ordertest_customerId',
+              'entity': 'CustomerTest3',
+              'entityKey': 'id',
+              'foreignKey': 'customerId',
+            },
+          },
+        },
+        'properties': {
+          'id': {
+            'type': 'String',
+            'length': 20,
+            'id': 1,
+          },
+          'customerId': {
+            'type': 'String',
+            'length': 20,
+          },
+          'description': {
+            'type': 'String',
+            'required': false,
+            'length': 40,
+          },
+        },
+      };
+
+      var orderTest_schema_v2 = {
+        'name': 'OrderTest',
+        'options': {
+          'idInjection': false,
+          'postgresql': {
+            'schema': 'myapp_test',
+            'table': 'order_test',
+          },
+          'foreignKeys': {
+            'fk_ordertest_customerId': {
+              'name': 'fk_ordertest_customerId',
+              'entity': 'CustomerTest2',
+              'entityKey': 'id',
+              'foreignKey': 'customerId',
+            },
+          },
+        },
+        'properties': {
+          'id': {
+            'type': 'String',
+            'length': 20,
+            'id': 1,
+          },
+          'customerId': {
+            'type': 'String',
+            'length': 20,
+          },
+          'description': {
+            'type': 'String',
+            'required': false,
+            'length': 40,
+          },
+        },
+      };
+
+      var orderTest_schema_v3 = {
+        'name': 'OrderTest',
+        'options': {
+          'idInjection': false,
+          'postgresql': {
+            'schema': 'myapp_test',
+            'table': 'order_test',
+          },
+        },
+        'properties': {
+          'id': {
+            'type': 'String',
+            'length': 20,
+            'id': 1,
+          },
+          'customerId': {
+            'type': 'String',
+            'length': 20,
+          },
+          'description': {
+            'type': 'String',
+            'required': false,
+            'length': 40,
+          },
+        },
+      };
+
+      ds.createModel(customer2_schema.name, customer2_schema.properties, customer2_schema.options);
+      ds.createModel(customer3_schema.name, customer3_schema.properties, customer3_schema.options);
+
+      // Table create order is important. Referenced tables must exist before creating a reference.
+      // do initial update/creation of referenced tables
+      ds.autoupdate(function(err) {
+        assert(!err, err);
+
+        // do initial update/creation of table with fk
+        ds.createModel(orderTest_schema_v1.name, orderTest_schema_v1.properties, orderTest_schema_v1.options);
+        ds.autoupdate(function(err) {
+          assert(!err, err);
+          ds.discoverModelProperties('order_test', function(err, props) {
+            // validate that we have the correct number of properties
+            assert.equal(props.length, 3);
+
+            // get the foreign keys for order_test
+            ds.connector.discoverForeignKeys('order_test', {}, function(err, foreignKeys) {
+              assert(!err, err);
+              // validate that the foreign key exists and points to the right column
+              assert(foreignKeys);
+              assert.equal(foreignKeys.length, 1);
+              assert.equal(foreignKeys[0].pkColumnName, 'id');
+              assert.equal(foreignKeys[0].pkTableName, 'customer_test3');
+              // note: column names are converted to lowercase by postgres
+              assert.equal(foreignKeys[0].fkColumnName, 'customerid');
+              assert.equal(foreignKeys[0].fkName, 'fk_ordertest_customerId');
+
+              // update fk
+              ds.createModel(orderTest_schema_v2.name, orderTest_schema_v2.properties, orderTest_schema_v2.options);
+              ds.autoupdate(function(err) {
+                assert(!err, err);
+                ds.discoverModelProperties('order_test', function(err, props) {
+                  // validate that we have the correct number of properties
+                  assert.equal(props.length, 3);
+
+                  // get the foreign keys for order_test
+                  ds.connector.discoverForeignKeys('order_test', {}, function(err, foreignKeysUpdated) {
+                    assert(!err, err);
+                    // validate that the foreign key exists and points to the new column
+                    assert(foreignKeysUpdated);
+                    assert.equal(foreignKeysUpdated.length, 1);
+                    assert.equal(foreignKeysUpdated[0].pkColumnName, 'id');
+                    assert.equal(foreignKeysUpdated[0].pkTableName, 'customer_test2');
+                    // note: column names are converted to lowercase by postgres
+                    assert.equal(foreignKeysUpdated[0].fkColumnName, 'customerid');
+                    assert.equal(foreignKeysUpdated[0].fkName, 'fk_ordertest_customerId');
+
+                      // remove fk
+                    ds.createModel(orderTest_schema_v3.name, orderTest_schema_v3.properties,
+                      orderTest_schema_v3.options);
+                    ds.autoupdate(function(err) {
+                      assert(!err, err);
+                      ds.discoverModelProperties('order_test', function(err, props) {
+                        // validate that we have the correct number of properties
+                        assert.equal(props.length, 3);
+
+                        // get the foreign keys for order_test
+                        ds.connector.discoverForeignKeys('order_test', {}, function(err, foreignKeysEmpty) {
+                          if (err) return done(err);
+                          assert(foreignKeysEmpty);
+                          assert.equal(foreignKeysEmpty.length, 0);
+                          done();
+                        });
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description
Support adding and removing foreign key constraints.

Support for adding and removing foreign key constraints. I marked this as WIP since there are a couple of TODO items.
- [x] support FK table update
- [x] fix camelCase issue for foreign key ids

 I wanted to get some feedback in the meantime.

#### Related issues

- connect to https://github.com/strongloop/loopback-connector-postgresql/issues/348

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Documentation in README.md was updated 
