### PR TITLE
fix: multiple fk on a property

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -108,13 +108,6 @@ function mixinMigration(PostgreSQL) {
         return;
       }
 
-      // actualFks is a list of EXISTING fkeys here,
-      // so you don't need to recreate them again
-      // prepare fkSQL for new foreign keys
-      var fkSQL = self.getForeignKeySQL(model,
-        self.getModelDefinition(model).settings.foreignKeys,
-        actualFks);
-
       async.series([
         function(cb) {
           applyPending([
@@ -127,6 +120,13 @@ function mixinMigration(PostgreSQL) {
           self.addIndexes(model, actualIndexes, cb);
         },
         function(cb) {
+          // actualFks is a list of EXISTING fkeys here,
+          // so you don't need to recreate them again
+          // prepare fkSQL for new foreign keys
+          var fkSQL = self.getForeignKeySQL(model,
+            self.getModelDefinition(model).settings.foreignKeys,
+            actualFks);
+
           self.addForeignKeys(model, fkSQL, cb);
         },
       ], function(err, result) {
@@ -330,7 +330,9 @@ function mixinMigration(PostgreSQL) {
               if (err) {
                 return cb(err);
               }
-              self.addForeignKeys(model, function(err, result) {
+              var fkSQL = self.getForeignKeySQL(model,
+                self.getModelDefinition(model).settings.foreignKeys);
+              self.addForeignKeys(model, fkSQL, function(err, result) {
                 cb(err);
               });
             });
@@ -498,18 +500,6 @@ function mixinMigration(PostgreSQL) {
 
   PostgreSQL.prototype.addForeignKeys = function(model, fkSQL, cb) {
     var self = this;
-    var m = this.getModelDefinition(model);
-
-    if ((!cb) && ('function' === typeof fkSQL)) {
-      cb = fkSQL;
-      fkSQL = undefined;
-    }
-
-    if (!fkSQL || fkSQL.length === 0) {
-      var newFks = m.settings.foreignKeys;
-      if (newFks)
-        fkSQL = self.getForeignKeySQL(model, newFks);
-    }
 
     if (fkSQL && fkSQL.length) {
       self.applySqlChanges(model, [fkSQL.toString()], function(err, result) {
@@ -539,16 +529,23 @@ function mixinMigration(PostgreSQL) {
           var fkRefKey = newFk.entityKey;
           var fkEntityName = (typeof newFk.entity === 'object') ? newFk.entity.name : newFk.entity;
           var fkRefTable = self.table(fkEntityName);
-          needsToDrop = fkCol != fk.fkColumnName ||
-                        fkRefKey != fk.pkColumnName ||
-                        fkRefTable != fk.pkTableName;
+          needsToDrop = !isCaseInsensitiveEqual(fkCol, fk.fkColumnName) ||
+                        !isCaseInsensitiveEqual(fkRefKey, fk.pkColumnName) ||
+                        !isCaseInsensitiveEqual(fkRefTable, fk.pkTableName);
         } else {
-          needsToDrop = true;
+          // only if FK is in model properties then need to drop
+          if (hasColumnProperty(m.properties, fk.fkColumnName)) {
+            needsToDrop = true;
+          }
         }
 
         if (needsToDrop) {
           sql.push('DROP CONSTRAINT ' + self.escapeName(fk.fkName));
           removedFks.push(fk); // keep track that we removed these
+        }
+
+        if (sql.length > 0) {
+          sql = [sql.join(', ')];
         }
       });
 
@@ -601,6 +598,29 @@ function mixinMigration(PostgreSQL) {
     }
     return '';
   };
+
+  /*!
+   * Case insensitive comparison of two strings
+   * @param {String} val1
+   * @param {String} val2
+   */
+  function isCaseInsensitiveEqual(val1, val2) {
+    return val1.toLowerCase() === val2.toLowerCase();
+  }
+  /*!
+   * Case insensitive comparison of object properties
+   * @param {Object} properties
+   * @param {String} name
+   */
+  function hasColumnProperty(properties, name) {
+    if (!name) { return false; }
+
+    return (Object.keys(properties)
+      .map(function(k) {
+        return k.toLowerCase();
+      })
+      .indexOf(name.toLowerCase()) > -1);
+  }
 
   /*!
    * Map postgresql data types to json types

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -533,6 +533,7 @@ function mixinMigration(PostgreSQL) {
                         !isCaseInsensitiveEqual(fkRefKey, fk.pkColumnName) ||
                         !isCaseInsensitiveEqual(fkRefTable, fk.pkTableName);
         } else {
+          // FK will be dropped if column is removed
           // only if FK is in model properties then need to drop
           if (hasColumnProperty(m.properties, fk.fkColumnName)) {
             needsToDrop = true;


### PR DESCRIPTION
### Description
- Fix multiple foreign keys on same model
- Fix case sensitivity when dropping multiple FK
- If FK property is removed then FK will automatically be dropped, so prevent DROP FK command for this case

#### Related issues

- connect to https://github.com/strongloop/loopback-connector-postgresql/issues/359


### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
