### PR TITLE
fix: use original prop name to search fields

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -133,7 +133,7 @@ function mixinMigration(PostgreSQL) {
     propNames.forEach(function(propName) {
       if (self.id(model, propName)) return;
       var found = self.searchForPropertyInActual(
-        model, self.column(model, propName), actualFields);
+        model, propName, actualFields);
       if (!found && self.propertyHasNotBeenDeleted(model, propName)) {
         sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));
       }


### PR DESCRIPTION
### Description
When calling `searchForPropertyInActual`, we should provide the actual prop name since the function itself in [loopback-connector](https://github.com/strongloop/loopback-connector/blob/master/lib/sql.js#L152-L162) calls `self.column` in order to find a column inside the fields which matches the property name.

Discovered this bug when I was working on #364.

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
