### PR TITLE
Fix bug cannot create foreign key

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -593,7 +593,7 @@ function mixinMigration(PostgreSQL) {
       // verify that the other model in the same DB
       if (this._models[fkEntityName]) {
         return 'CONSTRAINT ' + this.escapeName(fk.name) + ' ' +
-          'FOREIGN KEY (' + fk.foreignKey + ') ' +
+          'FOREIGN KEY (' + this.escapeName(fk.foreignKey) + ') ' +
           'REFERENCES ' + this.tableEscaped(fkEntityName) + '(' + fk.entityKey + ')';
       }
     }

--- a/test/postgresql.autoupdate.test.js
+++ b/test/postgresql.autoupdate.test.js
@@ -477,6 +477,9 @@ describe('autoupdate', function() {
           'customerId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'customerId',
+            },
           },
           'description': {
             'type': 'String',
@@ -512,6 +515,9 @@ describe('autoupdate', function() {
           'customerId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'customerId',
+            },
           },
           'description': {
             'type': 'String',
@@ -521,6 +527,9 @@ describe('autoupdate', function() {
           'productId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'productId',
+            },
           },
         },
       };
@@ -557,6 +566,9 @@ describe('autoupdate', function() {
           'customerId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'customerId',
+            },
           },
           'description': {
             'type': 'String',
@@ -566,6 +578,9 @@ describe('autoupdate', function() {
           'productId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'productId',
+            },
           },
         },
       };
@@ -588,10 +603,16 @@ describe('autoupdate', function() {
           'customerId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'customerId',
+            },
           },
           'productId': {
             'type': 'String',
             'length': 20,
+            'postgresql': {
+              'columnName': 'productId',
+            },
           },
           'description': {
             'type': 'String',
@@ -626,8 +647,7 @@ describe('autoupdate', function() {
               assert.equal(foreignKeys.length, 1);
               assert.equal(foreignKeys[0].pkColumnName, 'id');
               assert.equal(foreignKeys[0].pkTableName, 'customer_test3');
-              // note: column names are converted to lowercase by postgres
-              assert.equal(foreignKeys[0].fkColumnName, 'customerid');
+              assert.equal(foreignKeys[0].fkColumnName, 'customerId');
               assert.equal(foreignKeys[0].fkName, 'fk_ordertest_customerId');
 
               // update and add another fk
@@ -646,8 +666,7 @@ describe('autoupdate', function() {
                     assert.equal(foreignKeysUpdated.length, 1);
                     assert.equal(foreignKeysUpdated[0].pkColumnName, 'id');
                     assert.equal(foreignKeysUpdated[0].pkTableName, 'customer_test2');
-                    // note: column names are converted to lowercase by postgres
-                    assert.equal(foreignKeysUpdated[0].fkColumnName, 'customerid');
+                    assert.equal(foreignKeysUpdated[0].fkColumnName, 'customerId');
                     assert.equal(foreignKeysUpdated[0].fkName, 'fk_ordertest_customerId');
 
                     // create multiple fks on object


### PR DESCRIPTION
### Description
If the foreign key is lower case, it can be created. But if it has any character uppercase. I cannot create. 
I fix it by simple modify `this.escapeName(fk.foreignKey)`

![image](https://user-images.githubusercontent.com/5670932/54380951-3269c080-46bf-11e9-9c46-542991b889a8.png)


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->



### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
