### PR TITLE
Use canonical index name when dropping

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -744,6 +744,7 @@ function mixinMigration(PostgreSQL) {
 
     // remove indexes
     aiNames.forEach(function(indexName) {
+      var schema = self.escapeName(self.schema(model) || 'public');
       var i = ai[indexName];
       var propName = propNameRegEx.exec(indexName);
       var si; // index definition from model schema
@@ -753,7 +754,7 @@ function mixinMigration(PostgreSQL) {
       propName = propName && self.propertyName(model, propName[1]) || null;
       if (!(indexNames.indexOf(indexName) > -1) && !(propName && m.properties[propName] &&
       m.properties[propName].index)) {
-        sql.push('DROP INDEX ' + self.escapeName(indexName));
+        sql.push('DROP INDEX ' + schema + '.' + self.escapeName(indexName));
       } else {
         // The index was found, verify that database matches what we're expecting.
         // first: check single column indexes.
@@ -765,7 +766,7 @@ function mixinMigration(PostgreSQL) {
               !((!si.type || si.type === ai[indexName].type) && (!si.unique || si.unique === ai[indexName].unique))
             ) {
               // Drop the index if the type or unique differs from the actual table
-              sql.push('DROP INDEX ' + self.escapeName(indexName));
+              sql.push('DROP INDEX ' + schema + '.' + self.escapeName(indexName));
               delete ai[indexName];
             }
           }
@@ -791,7 +792,7 @@ function mixinMigration(PostgreSQL) {
           }
 
           if (!identical) {
-            sql.push('DROP INDEX ' + self.escapeName(indexName));
+            sql.push('DROP INDEX ' + schema + '.' + self.escapeName(indexName));
             delete ai[indexName];
           }
         }

--- a/test/postgresql.autoupdate.test.js
+++ b/test/postgresql.autoupdate.test.js
@@ -689,4 +689,53 @@ describe('autoupdate', function() {
       });
     });
   });
+
+  describe('indexes on table in schema', function() {
+    var schema = {
+      options: {
+        postgresql: {
+          schema: 'aschema',
+        },
+      },
+      properties: {
+        something: {
+          type: 'string',
+          index: true,
+        },
+      },
+    };
+
+    var changedSchema = Object.assign({}, schema, {
+      properties: {
+        something: {
+          type: 'string',
+          index: false,
+        },
+      },
+    });
+
+    afterEach(function(done) {
+      ds.adapter.dropTable('ATable', done);
+    });
+
+    it('should update without errors', function(done) {
+      ds.define('ATable', schema.properties, schema.options);
+      ds.autoupdate(['ATable'], function(err) {
+        assert(!err, err);
+        done();
+      });
+    });
+
+    it('should be removed successfully', function(done) {
+      ds.define('ATable', schema.properties, schema.options);
+      ds.autoupdate(['ATable'], function(err) {
+        assert(!err, err);
+        ds.define('ATable', changedSchema.properties, changedSchema.options);
+        ds.autoupdate(['ATable'], function(err) {
+          assert(!err, err);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Should fix #354

### Description
Add the schema name to index name when dropping indices, otherwise the migration script can fail 
due to not being able to find the index, or not being able to re-create the index because it never dropped it.

#### Related issues

- connect to 354

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

Sadly I don't have time to write tests or check the style (I copied the surrounding code style, so should be fine?), but it shouldn't break any existing tests.