### PR TITLE
chore: connector flag for no array type support

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -58,6 +58,9 @@ global.getDataSource = global.getSchema = function(useUrl) {
 global.connectorCapabilities = {
   ilike: false,
   nilike: false,
+  // TODO: [b-admike] we do not support arrays at the moment
+  // see https://github.com/strongloop/loopback-connector-postgresql/issues/342
+  supportsArrays: false,
 };
 
 global.sinon = require('sinon');


### PR DESCRIPTION
### Description
Add flag to let recently added Juggler tests know that PostgreSQL connector doesn't currently support array data type. See https://github.com/strongloop/loopback-connector-postgresql/issues/342 for more info. Once we have support for it, this flag can be removed.


- [ N/A] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
