### PR TITLE
Run shared tests from both v3 and v4 of juggler

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/deps/juggler-v3/package.json
+++ b/deps/juggler-v3/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "juggler-v3",
+  "version": "3.0.0",
+  "dependencies": {
+    "loopback-datasource-juggler":"3.x",
+    "should": "^8.4.0"
+  }
+}

--- a/deps/juggler-v3/test.js
+++ b/deps/juggler-v3/test.js
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-connector-mysql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var should = require('../../test/init');
+var juggler = require('loopback-datasource-juggler');
+var name = require('./package.json').name;
+
+describe(name, function() {
+  before(function() {
+    return global.resetDataSourceClass(juggler.DataSource);
+  });
+
+  after(function() {
+    return global.resetDataSourceClass();
+  });
+
+  require('loopback-datasource-juggler/test/common.batch.js');
+  require('loopback-datasource-juggler/test/include.test.js');
+
+  /* TODO: run persistence-hooks test suite too
+  var testHooks = require('loopback-datasource-juggler/test/persistence-hooks.suite.js');
+  testHooks(global.getDataSource(), should, {
+    replaceOrCreateReportsNewInstance: false,
+  });
+  */
+});

--- a/deps/juggler-v4/package.json
+++ b/deps/juggler-v4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "juggler-v4",
+  "version": "4.0.0",
+  "dependencies": {
+    "loopback-datasource-juggler":"4.x",
+    "should": "^13.2.3"
+  }
+}

--- a/deps/juggler-v4/test.js
+++ b/deps/juggler-v4/test.js
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-connector-mysql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+// Skip the tests on Node.js versions not supported by juggler v4
+// TODO(bajtos): remove this check when we drop Node.js 6 from our CI matrix
+var nodeMajor = +process.versions.node.split('.')[0];
+if (nodeMajor < 8) {
+  return;
+}
+
+var should = require('../../test/init');
+var juggler = require('loopback-datasource-juggler');
+var name = require('./package.json').name;
+
+describe(name, function() {
+  before(function() {
+    return global.resetDataSourceClass(juggler.DataSource);
+  });
+
+  after(function() {
+    return global.resetDataSourceClass();
+  });
+
+  require('loopback-datasource-juggler/test/common.batch.js');
+  require('loopback-datasource-juggler/test/include.test.js');
+
+  /* TODO: run persistence-hooks test suite too
+  var testHooks = require('loopback-datasource-juggler/test/persistence-hooks.suite.js');
+  testHooks(global.getDataSource(), should, {
+    replaceOrCreateReportsNewInstance: false,
+  });
+  */
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "node pretest.js",
-    "test": "mocha -R spec --timeout 10000 --require test/init.js test/*.test.js",
+    "test": "mocha test/*.test.js",
     "lint": "eslint .",
     "posttest": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "node pretest.js",
-    "test": "mocha test/*.test.js",
+    "test": "mocha test/*.test.js node_modules/juggler-v3/test.js node_modules/juggler-v4/test.js",
     "lint": "eslint .",
     "posttest": "npm run lint"
   },
@@ -31,8 +31,10 @@
   "devDependencies": {
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
+    "juggler-v3": "file:./deps/juggler-v3",
+    "juggler-v4": "file:./deps/juggler-v4",
     "lodash": "^4.17.4",
-    "loopback-datasource-juggler": "^3.0.0",
+    "loopback-datasource-juggler": "^3.0.0 || ^4.0.0",
     "mocha": "^5.0.0",
     "rc": "^1.0.0",
     "should": "^8.0.2",

--- a/test/init.js
+++ b/test/init.js
@@ -4,7 +4,8 @@
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
 'use strict';
-var DataSource = require('loopback-datasource-juggler').DataSource;
+var juggler = require('loopback-datasource-juggler');
+var DataSource = juggler.DataSource;
 
 var config = require('rc')('loopback', {test: {postgresql: {}}}).test.postgresql;
 
@@ -53,6 +54,13 @@ global.getDataSource = global.getSchema = function(useUrl) {
     // console.log(a);
   };
   return db;
+};
+
+global.resetDataSourceClass = function(ctor) {
+  DataSource = ctor || juggler.DataSource;
+  var promise = db ? db.disconnect() : Promise.resolve();
+  db = undefined;
+  return promise;
 };
 
 global.connectorCapabilities = {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--reporter spec
+--timeout 10000
+--require test/init.js
+--exit

--- a/test/postgresql.autoupdate.test.js
+++ b/test/postgresql.autoupdate.test.js
@@ -629,19 +629,27 @@ describe('autoupdate', function() {
       // Table create order is important. Referenced tables must exist before creating a reference.
       // do initial update/creation of referenced tables
       ds.autoupdate(function(err) {
-        assert(!err, err);
+        if (err) {
+          err.message += ' (while running initial autoupdate)';
+          return done(err);
+        }
 
         // do initial update/creation of table with fk
         ds.createModel(orderTest_schema_v1.name, orderTest_schema_v1.properties, orderTest_schema_v1.options);
         ds.autoupdate(function(err) {
-          assert(!err, err);
+          if (err) {
+            err.message += ' (while updating OrderTest schema v1)';
+            return done(err);
+          }
           ds.discoverModelProperties('order_test', function(err, props) {
+            if (err) return done(err);
             // validate that we have the correct number of properties
             assert.equal(props.length, 3);
 
             // get the foreign keys for order_test
             ds.connector.discoverForeignKeys('order_test', {}, function(err, foreignKeys) {
-              assert(!err, err);
+              if (err) return done(err);
+
               // validate that the foreign key exists and points to the right column
               assert(foreignKeys);
               assert.equal(foreignKeys.length, 1);
@@ -653,14 +661,18 @@ describe('autoupdate', function() {
               // update and add another fk
               ds.createModel(orderTest_schema_v2.name, orderTest_schema_v2.properties, orderTest_schema_v2.options);
               ds.autoupdate(function(err) {
-                assert(!err, err);
+                if (err) {
+                  err.message += ' (while updating OrderTest schema v2)';
+                  return done(err);
+                }
                 ds.discoverModelProperties('order_test', function(err, props) {
+                  if (err) return done(err);
                   // validate that we have the correct number of properties
                   assert.equal(props.length, 4);
 
                   // get the foreign keys for order_test
                   ds.connector.discoverForeignKeys('order_test', {}, function(err, foreignKeysUpdated) {
-                    assert(!err, err);
+                    if (err) return done(err);
                     // validate that the foreign keys exist and point to the new column
                     assert(foreignKeysUpdated);
                     assert.equal(foreignKeysUpdated.length, 1);
@@ -673,9 +685,13 @@ describe('autoupdate', function() {
                     ds.createModel(orderTest_schema_v3.name, orderTest_schema_v3.properties,
                       orderTest_schema_v3.options);
                     ds.autoupdate(function(err) {
+                      if (err) {
+                        err.message += ' (while updating OrderTest schema v3)';
+                        return done(err);
+                      }
                       // get the foreign keys for order_test
                       ds.connector.discoverForeignKeys('order_test', {}, function(err, foreignKeysMulti) {
-                        assert(!err, err);
+                        if (err) return done(err);
                         assert(foreignKeysMulti);
                         assert.equal(foreignKeysMulti.length, 2);
 
@@ -683,8 +699,13 @@ describe('autoupdate', function() {
                         ds.createModel(orderTest_schema_v4.name, orderTest_schema_v4.properties,
                           orderTest_schema_v4.options);
                         ds.autoupdate(function(err) {
-                          assert(!err, err);
+                          if (err) {
+                            err.message += ' (while updating OrderTest schema v4)';
+                            return done(err);
+                          }
                           ds.discoverModelProperties('order_test', function(err, props) {
+                            if (err) return done(err);
+
                             // validate that we have the correct number of properties
                             assert.equal(props.length, 4);
 

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -6,8 +6,6 @@
 'use strict';
 var juggler = require('loopback-datasource-juggler');
 var CreateDS = juggler.DataSource;
-require('loopback-datasource-juggler/test/common.batch.js');
-require('loopback-datasource-juggler/test/include.test.js');
 
 require('./init');
 var async = require('async');


### PR DESCRIPTION
At the moment, our connectors are installing juggler 3.x to run the test suite. When we make a change to juggler@3, cis-jenkins detects downstream dependency and triggers CI build of connectors with the modified juggler version. When we make a change to juggler's master, no downstream builds are triggered.

In the past, we were maintaining multiple branches to test connectors against different juggler versions. E.g. `loopback-2.x` containing code from "master" but installing juggler 2.x for testing. This is rather impractical, because we don't have bandwidth to update those other branches with changes made to master.

In this pull request, I am reworking connector test setup to execute tests from both juggler versions 3.x and 4.x.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
