### PR TITLE
Fix Index upgrade

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -783,8 +783,7 @@ function mixinMigration(PostgreSQL) {
           if (identical && siKeys.length > 1) {
             if (siKeys.length !== i.keys.length) {
               // lengths differ, obviously non-matching
-              // ??? orderMatched is not defined and not used anywhere else
-              // orderMatched = false;
+              identical = false;
             } else {
               siKeys.forEach(function(propName, iter) {
                 identical = identical && self.column(model, propName) === i.keys[iter];

--- a/test/postgresql.autoupdate.test.js
+++ b/test/postgresql.autoupdate.test.js
@@ -512,6 +512,10 @@ describe('autoupdate', function() {
             'length': 20,
             'id': 1,
           },
+          'subid': {
+            'type': 'int',
+            'id': 1,
+          },
           'customerId': {
             'type': 'String',
             'length': 20,
@@ -598,6 +602,10 @@ describe('autoupdate', function() {
           'id': {
             'type': 'String',
             'length': 20,
+            'id': 1,
+          },
+          'subid': {
+            'type': 'int',
             'id': 1,
           },
           'customerId': {


### PR DESCRIPTION
### Description

Seems like syntax error:
- autoupdate not working due to variable is unset
- without this change (just comment this line) Indexes was not updated

https://github.com/strongloop/loopback-connector-postgresql/issues/379

