### PR TITLE
Drop support for Node.js 6

### DIFF
--- a/deps/juggler-v4/test.js
+++ b/deps/juggler-v4/test.js
@@ -5,13 +5,6 @@
 
 'use strict';
 
-// Skip the tests on Node.js versions not supported by juggler v4
-// TODO(bajtos): remove this check when we drop Node.js 6 from our CI matrix
-var nodeMajor = +process.versions.node.split('.')[0];
-if (nodeMajor < 8) {
-  return;
-}
-
 var should = require('../../test/init');
 var juggler = require('loopback-datasource-juggler');
 var name = require('./package.json').name;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.1",
   "description": "Loopback PostgreSQL Connector",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
- Node.js 6.x has reached EOL
- cis-jenkins has a bug where it runs downstream tests of juggler@4 (supporting Node.js 8+ only) on the minimum Node.js version supported by the connector (Node.js 6), which triggers the check skipping juggler@4 tests.

This change will be published as semver-minor release.