### PR TITLE
Fix - fail to honor non-unique property constraint

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -823,7 +823,7 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && !type && typeof i === 'object' || i.unique && i.unique === true) {
+        if (!kind && !type && typeof i === 'object' && i.unique && i.unique === true) {
           kind = ' UNIQUE ';
         }
 


### PR DESCRIPTION
Connector does not honor non-unique index definition for a property declaration in model json file on automigrate/autoupdate.  Error is generated on autoupdate when adding this non-unique data already exists.  Error is generated when instances are inserted that contain a value for the property that already exists in the database.

Example model json file snipet:
```
"properties": [ 
  "email": {
    "type": "String",
    "index": {
      "unique": false
    }
  }
]
```

error generated: "could not create unique index "[modelname] _email_idx"

### Description


#### Related issues
https://github.com/strongloop/loopback-connector-postgresql/issues/336
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
