### PR TITLE
Fix eslint violations

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -157,7 +157,7 @@ function mixinMigration(PostgreSQL) {
     propNames.forEach(function(propName) {
       if (self.id(model, propName)) return;
       const found = self.searchForPropertyInActual(
-        model, self.column(model, propName), actualFields
+        model, self.column(model, propName), actualFields,
       );
       if (!found && self.propertyHasNotBeenDeleted(model, propName)) {
         sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));

--- a/test/postgresql.migration.test.js
+++ b/test/postgresql.migration.test.js
@@ -150,7 +150,7 @@ function getIndexes(model, cb) {
         });
       }
       cb(err, indexes);
-    }
+    },
   );
 }
 

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -153,7 +153,7 @@ describe('postgresql connector', function() {
           p.created.getTime().should.be.eql(created.getTime());
           done();
         });
-      }
+      },
     );
   });
 
@@ -169,7 +169,7 @@ describe('postgresql connector', function() {
           results.should.have.property('affectedRows', 1);
           done(err);
         });
-      }
+      },
     );
   });
 
@@ -186,7 +186,7 @@ describe('postgresql connector', function() {
           results.rows[0].id.should.eql(post.id);
           done(err);
         });
-      }
+      },
     );
   });
 
@@ -212,7 +212,7 @@ describe('postgresql connector', function() {
           p.should.have.property('approved', false);
           done();
         });
-      }
+      },
     );
   });
 

--- a/test/postgresql.timestamp.test.js
+++ b/test/postgresql.timestamp.test.js
@@ -56,7 +56,7 @@ describe('Timestamps', function() {
           should.not.exist(err);
           should.exist(p);
           done();
-        }
+        },
       );
     });
 


### PR DESCRIPTION
Run `eslint --fix .` to add trailing commas to function arguments.

The linting errors were discovered by https://github.com/strongloop/loopback-connector/pull/157.