### PR TITLE
Use db type jsonb to support dot notation filters

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -21,7 +21,7 @@ function mixinMigration(PostgreSQL) {
     const tableName = self.table(modelName);
     let _foreignKeys = m.settings.foreignKeys;
     Object.defineProperty(m.settings, 'foreignKeys', {
-      get : function () {
+      get : () => {
         function addForeignKey(keyFrom, modelTo, keyTo) {
           const foreignColumn = self.column(modelName, keyFrom);
           const constraintName = tableName + '_' + foreignColumn + '_fkey';
@@ -29,7 +29,7 @@ function mixinMigration(PostgreSQL) {
             _foreignKeys = {};  // lazy init
           }
           // don't duplicate 
-          if (!Object.values(_foreignKeys).some(function (aForeignKey) {
+          if (!Object.values(_foreignKeys).some((aForeignKey) => {
             return aForeignKey.foreignKey === foreignColumn;
             })) {
             _foreignKeys[constraintName] = {
@@ -72,8 +72,8 @@ function mixinMigration(PostgreSQL) {
 
     let _indexes = m.settings.indexes || {};
     Object.defineProperty(m.settings, 'indexes', {
-      get : function () {
-        // implicit intervening model of many-to-many (without explicit through)
+      get : () => {
+         // implicit intervening model of many-to-many (without explicit through)
         if (!model.app) {
           const columnsNames = Object.entries(m.properties).
           filter(function ([propName, prop]) {
@@ -91,12 +91,12 @@ function mixinMigration(PostgreSQL) {
           }
           joinedColumnNames = joinedColumnNames.toLowerCase();
 
-          if (!Object.entries(_indexes).some(function([anIndexName, anIndex]) {
+          if (!Object.entries(_indexes).some(([anIndexName, anIndex]) => {
             return anIndexName.toLowerCase() === indexName.toLowerCase() &&
               Object.keys(anIndex.keys).sort().join('_').toLowerCase() !==
               joinedColumnNames})) {
             // the index name and the keys are not duplicated  
-            const key = columnsNames.reduce(function(key, columName, index) {
+            const key = columnsNames.reduce((key, columName, index) => {
               key[columName] = index + 1;
               return key;
             }, {});
@@ -106,6 +106,30 @@ function mixinMigration(PostgreSQL) {
                 unique: true
               }
             };
+          }
+        }
+        else {
+          const modelName = model.modelName;
+          for (const [relname, relation] of Object.entries(m.model.relations)) {
+            if (relation.type === 'belongsTo') {
+              const polymorphic = relation.polymorphic;
+              if (polymorphic) {
+                const discriminator = self.column(modelName, polymorphic.discriminator);
+                const foreignKey = self.column(modelName, polymorphic.foreignKey);
+                const iName = [self.table(modelName), 
+                  discriminator, foreignKey, 'key'].join('_');
+                _indexes[iName] = {
+                  keys: {
+                    [discriminator] : 1,
+                    [foreignKey] : 2
+                  },
+                  options: {
+                    unique: true
+                  }
+                };
+                delete m.properties[polymorphic.discriminator].index;
+              }
+            }
           }
         }
         return _indexes;

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -12,6 +12,107 @@ const debug = require('debug')('loopback:connector:postgresql:migration');
 module.exports = mixinMigration;
 
 function mixinMigration(PostgreSQL) {
+  PostgreSQL.prototype._define = PostgreSQL.prototype.define;
+  PostgreSQL.prototype.define = function(m) {
+    this._define(m);
+    const self = this;
+    const model = m.model;
+    const modelName = model.modelName;
+    const tableName = self.table(modelName);
+    let _foreignKeys = m.settings.foreignKeys;
+    Object.defineProperty(m.settings, 'foreignKeys', {
+      get : function () {
+        function addForeignKey(keyFrom, modelTo, keyTo) {
+          const foreignColumn = self.column(modelName, keyFrom);
+          const constraintName = tableName + '_' + foreignColumn + '_fkey';
+          if (!_foreignKeys) {
+            _foreignKeys = {};  // lazy init
+          }
+          // don't duplicate 
+          if (!Object.values(_foreignKeys).some(function (aForeignKey) {
+            return aForeignKey.foreignKey === foreignColumn;
+            })) {
+            _foreignKeys[constraintName] = {
+              name: constraintName,
+              entity: self.table(modelTo),
+              entityKey: self.column(modelTo, keyTo),
+              foreignKey: foreignColumn
+            };
+          }
+        }
+
+        // find hasOne non-polymorphic references to this model
+        for (let propName of Object.keys(m.properties || {})) {
+          Object.values(self._models).some(function (definition) {
+            let aModel = definition.model;
+            return (Object.values(aModel.relations || {}).some(function (relation) {
+              const foreignRelation = relation.keyTo;
+              if (!relation.polymorphic && relation.type === 'hasOne' && 
+                  relation.modelTo.modelName === modelName  && 
+                  foreignRelation === propName) {
+                addForeignKey(foreignRelation, 
+                  relation.modelFrom.modelName, relation.keyFrom);
+                return true;
+              }
+              return false;
+            }));
+          });
+        }
+
+        // find belongsTo relations from this model
+        for (let relation of Object.values(model.relations || {})) {
+          if (!relation.polymorphic && relation.type === 'belongsTo') {
+            addForeignKey(relation.keyFrom, 
+              relation.modelTo.modelName, relation.keyTo);
+          }
+        }
+        return _foreignKeys;
+      }
+    });
+
+    let _indexes = m.settings.indexes || {};
+    Object.defineProperty(m.settings, 'indexes', {
+      get : function () {
+        // implicit intervening model of many-to-many (without explicit through)
+        if (!model.app) {
+          const columnsNames = Object.entries(m.properties).
+          filter(function ([propName, prop]) {
+            return !prop.id;
+          }).map(function ([propName, prop]) {
+            model.definition.properties[propName].required = true;
+            prop.required = true;
+            return self.column(model.modelName, propName);
+          }).sort();
+          let joinedColumnNames = columnsNames.join('_');
+          const indexName = self.table(model.modelName) + '_' + 
+            joinedColumnNames + '_key';
+          if (!_indexes) {  
+            _indexes = {}; // lazy init
+          }
+          joinedColumnNames = joinedColumnNames.toLowerCase();
+
+          if (!Object.entries(_indexes).some(function([anIndexName, anIndex]) {
+            return anIndexName.toLowerCase() === indexName.toLowerCase() &&
+              Object.keys(anIndex.keys).sort().join('_').toLowerCase() !==
+              joinedColumnNames})) {
+            // the index name and the keys are not duplicated  
+            const key = columnsNames.reduce(function(key, columName, index) {
+              key[columName] = index + 1;
+              return key;
+            }, {});
+            _indexes[indexName] = {
+              keys: key,
+              options: {
+                unique: true
+              }
+            };
+          }
+        }
+        return _indexes;
+      }
+    });
+  }
+
   PostgreSQL.prototype.checkFieldAndIndex = function(fields, indexes) {
     if (fields && indexes)
       return true;
@@ -82,6 +183,7 @@ function mixinMigration(PostgreSQL) {
     const indexNames = m.settings.indexes ? Object.keys(m.settings.indexes).filter(function(name) {
       return !!m.settings.indexes[name];
     }) : [];
+    
 
     const applyPending = function(actions, cb, err, result) {
       const action = actions.shift();
@@ -332,7 +434,7 @@ function mixinMigration(PostgreSQL) {
             return cb(err);
           }
           const fkSQL = self.getForeignKeySQL(model,
-            self.getModelDefinition(model).settings.foreignKeys);
+          self.getModelDefinition(model).settings.foreignKeys);
           self.addForeignKeys(model, fkSQL, function(err, result) {
             cb(err);
           });
@@ -368,7 +470,7 @@ function mixinMigration(PostgreSQL) {
     const self = this;
     const indexClauses = [];
     const definition = this.getModelDefinition(model);
-    const indexes = definition.settings.indexes || {};
+    const indexes = definition || {};
     // Build model level indexes
     for (const index in indexes) {
       const i = indexes[index];
@@ -480,7 +582,8 @@ function mixinMigration(PostgreSQL) {
     switch (p.type.name) {
       default:
       case 'JSON':
-        return 'JSONB';
+        return this.pg.options.usejsonb? 'JSONB' : 'JSON';
+      case 'Any':
       case 'String':
       case 'Text':
         return 'TEXT';
@@ -516,7 +619,7 @@ function mixinMigration(PostgreSQL) {
 
     const fks = actualFks;
     let sql = [];
-    const correctFks = m.settings.foreignKeys || {};
+    const correctFks = m.settings.indexes || {};
 
     // drop foreign keys for removed fields
     if (fks && fks.length) {
@@ -584,7 +687,6 @@ function mixinMigration(PostgreSQL) {
 
   PostgreSQL.prototype.buildForeignKeyDefinition = function buildForeignKeyDefinition(model, keyName) {
     const definition = this.getModelDefinition(model);
-
     const fk = definition.settings.foreignKeys[keyName];
     if (fk) {
       // get the definition of the referenced object
@@ -692,7 +794,7 @@ function mixinMigration(PostgreSQL) {
         return 'GeoPoint';
 
       default:
-        return 'String';
+        return 'JSON';
     }
   }
 
@@ -725,8 +827,9 @@ function mixinMigration(PostgreSQL) {
     const propNames = Object.keys(m.properties).filter(function(name) {
       return !!m.properties[name];
     });
-    const indexNames = m.settings.indexes && Object.keys(m.settings.indexes).filter(function(name) {
-      return !!m.settings.indexes[name];
+    const indexes = m.settings.indexes;
+    const indexNames = indexes && Object.keys(indexes).filter(function(name) {
+      return !!indexes[name];
     }) || [];
     const sql = [];
     const ai = {};
@@ -844,11 +947,19 @@ function mixinMigration(PostgreSQL) {
 
         let type = '';
         let kind = '';
+        let nullable = '';
         if (i.type) {
           type = ' USING ' + i.type;
         }
         if (i.kind) {
           kind = i.kind;
+        }
+        if (i.options && i.options.nullable) {
+          nullable = ' WHERE ' + 
+            (Array.isArray(i.options.nullable)? i.options.nullable 
+                : [i.options.nullable]).map((col) => {
+              return self.escapeName(col)  + ' IS NULL';
+            }).join(' AND ');
         }
 
         if (i.options && i.options.unique && i.options.unique === true) {
@@ -856,7 +967,7 @@ function mixinMigration(PostgreSQL) {
         }
 
         sql.push('CREATE ' + kind + ' INDEX ' + iName + ' ON ' + self.tableEscaped(model) +
-        type + ' ( ' + columns + ')');
+        type + ' ( ' + columns + ')' + nullable);
       }
     });
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -479,9 +479,9 @@ function mixinMigration(PostgreSQL) {
     const p = propertyDefinition;
     switch (p.type.name) {
       default:
-      case 'String':
       case 'JSON':
-        return 'TEXT';
+        return 'JSONB';
+      case 'String':
       case 'Text':
         return 'TEXT';
       case 'Number':
@@ -783,8 +783,7 @@ function mixinMigration(PostgreSQL) {
           if (identical && siKeys.length > 1) {
             if (siKeys.length !== i.keys.length) {
               // lengths differ, obviously non-matching
-              // ??? orderMatched is not defined and not used anywhere else
-              // orderMatched = false;
+              identical = false;
             } else {
               siKeys.forEach(function(propName, iter) {
                 identical = identical && self.column(model, propName) === i.keys[iter];

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -417,6 +417,11 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
   operatorValue, propertyDefinition) {
   switch (operator) {
     case 'like':
+      const options = propertyDefinition.postgresql;
+      if (options && options.dataType == 'tsvector') {
+        return new ParameterizedSQL(columnName + "::TEXT @@ to_tsquery(?)",
+        [operatorValue]);
+      }
       return new ParameterizedSQL(columnName + "::TEXT LIKE ? ESCAPE E'\\\\'",
         [operatorValue]);
     case 'ilike':
@@ -552,43 +557,51 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
     if (expression === null || expression === undefined) {
       stmt.merge(columnName + ' IS NULL');
     } else if (expression && expression.constructor === Object) {
-      const operator = Object.keys(expression)[0];
-      // Get the expression without the operator
-      expression = expression[operator];
-      if (operator === 'inq' || operator === 'nin' || operator === 'between') {
-        columnValue = [];
-        if (Array.isArray(expression)) {
-          // Column value is a list
-          for (let j = 0, m = expression.length; j < m; j++) {
-            columnValue.push(this.toColumnValue(p, expression[j]));
+      if (Array.isArray(p.type)) {
+        stmt.merge({
+          sql: columnName + '@>?',
+          params: [JSON.stringify([expression])],
+        });
+      }
+      else {
+        const operator = Object.keys(expression)[0];
+        // Get the expression without the operator
+        expression = expression[operator];
+        if (operator === 'inq' || operator === 'nin' || operator === 'between') {
+          columnValue = [];
+          if (Array.isArray(expression)) {
+            // Column value is a list
+            for (let j = 0, m = expression.length; j < m; j++) {
+              columnValue.push(this.toColumnValue(p, expression[j]));
+            }
+          } else {
+            columnValue.push(this.toColumnValue(p, expression));
           }
-        } else {
-          columnValue.push(this.toColumnValue(p, expression));
-        }
-        if (operator === 'between') {
-          // BETWEEN v1 AND v2
-          const v1 = columnValue[0] === undefined ? null : columnValue[0];
-          const v2 = columnValue[1] === undefined ? null : columnValue[1];
-          columnValue = [v1, v2];
-        } else {
-          // IN (v1,v2,v3) or NOT IN (v1,v2,v3)
-          if (columnValue.length === 0) {
-            if (operator === 'inq') {
-              columnValue = [null];
-            } else {
-              // nin () is true
-              continue;
+          if (operator === 'between') {
+            // BETWEEN v1 AND v2
+            const v1 = columnValue[0] === undefined ? null : columnValue[0];
+            const v2 = columnValue[1] === undefined ? null : columnValue[1];
+            columnValue = [v1, v2];
+          } else {
+            // IN (v1,v2,v3) or NOT IN (v1,v2,v3)
+            if (columnValue.length === 0) {
+              if (operator === 'inq') {
+                columnValue = [null];
+              } else {
+                // nin () is true
+                continue;
+              }
             }
           }
+        } else if (operator === 'regexp' && expression instanceof RegExp) {
+          // do not coerce RegExp based on property definitions
+          columnValue = expression;
+        } else {
+          columnValue = this.toColumnValue(p, expression);
         }
-      } else if (operator === 'regexp' && expression instanceof RegExp) {
-        // do not coerce RegExp based on property definitions
-        columnValue = expression;
-      } else {
-        columnValue = this.toColumnValue(p, expression);
+        sqlExp = self.buildExpression(columnName, operator, columnValue, p);
+        stmt.merge(sqlExp);
       }
-      sqlExp = self.buildExpression(columnName, operator, columnValue, p);
-      stmt.merge(sqlExp);
     } else {
       // The expression is the field value, not a condition
       columnValue = self.toColumnValue(p, expression);
@@ -601,10 +614,18 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
           else
             stmt.merge(columnName + '=').merge(columnValue);
         } else {
-          stmt.merge({
-            sql: columnName + '=?',
-            params: [columnValue],
-          });
+          if (Array.isArray(p.type)) {
+            let c = /(\".*\")->>\'(.*)\'/g.exec(columnName);
+            stmt.merge({
+              sql: c[1] + '@>?',
+              params: [JSON.stringify([{ [c[2]] : columnValue}])],
+            });
+          } else {
+            stmt.merge({
+              sql: columnName + '=?',
+              params: [columnValue],
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
Using dot notation in query filters does not work because the database column type for object and embedded models is string.  This fixes the problem by changed the type to jsonb.