### PR TITLE
fix(pool): synchronously release pool connection after query results Fix/conn release

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -40,9 +40,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 
   if (callback) {
     if (dbSettings.lazyConnect) {
-      process.nextTick(function() {
-        callback();
-      });
+      process.nextTick(callback);
     } else {
       dataSource.connecting = true;
       dataSource.connector.connect(callback);
@@ -97,9 +95,9 @@ PostgreSQL.prototype.getDefaultSchemaName = function() {
  */
 PostgreSQL.prototype.connect = function(callback) {
   const self = this;
-  self.pg.connect(function(err, client, done) {
+  self.pg.connect(function(err, client, releaseCb) {
     self.client = client;
-    process.nextTick(done);
+    process.nextTick(releaseCb);
     callback && callback(err, client);
   });
 };
@@ -123,17 +121,13 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
     debug('SQL: %s', sql);
   }
 
-  function executeWithConnection(connection, done) {
+  function executeWithConnection(connection, releaseCb) {
     connection.query(sql, params, function(err, data) {
       // if(err) console.error(err);
       if (err) debug(err);
       if (data) debugData('%j', data);
-      if (done) {
-        process.nextTick(function() {
-          // Release the connection in next tick
-          done(err);
-        });
-      }
+      // Release the connection back to the pool.
+      if (releaseCb) releaseCb(err);
       let result = null;
       if (data) {
         switch (data.command) {
@@ -169,9 +163,9 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
     // Do not release the connection
     executeWithConnection(transaction.connection, null);
   } else {
-    self.pg.connect(function(err, connection, done) {
+    self.pg.connect(function(err, connection, releaseCb) {
       if (err) return callback(err);
-      executeWithConnection(connection, done);
+      executeWithConnection(connection, releaseCb);
     });
   }
 };


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Removes the `process.nextTick()` wrapping the [release callback](https://node-postgres.com/api/pool#pool.connect) after calling `pg.Pool#connect()`.

This was questioned in [this comment](https://github.com/strongloop/loopback-connector-postgresql/pull/52#discussion_r23476901) and never removed. We found test flakiness that was alleviated after removing this unnecessary tick.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
