### PR TITLE
fix: default values for where clause in select queries

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -715,6 +715,7 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
  */
 PostgreSQL.prototype.toColumnValue = function(prop, val) {
   if (val == null) {
+    // check ci
     // PostgreSQL complains with NULLs in not null columns
     // If we have an autoincrement value, return DEFAULT instead
     if (prop.autoIncrement || prop.id) {


### PR DESCRIPTION
fixes https://github.com/strongloop/loopback-connector-postgresql/issues/407

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
