### PR TITLE
fix discovered schema name with pascal case

### DIFF
--- a/test/postgresql.discover.test.js
+++ b/test/postgresql.discover.test.js
@@ -354,7 +354,7 @@ describe('Discover and map correctly database types', function() {
 describe('Discover and build models', function() {
   it('should build a model from discovery', function(done) {
     db.discoverAndBuildModels('GeoPoint', {schema: 'strongloop'}, function(err, schema) {
-      schema.Geopoint.find(function(err, data) {
+      schema.GeoPoint.find(function(err, data) {
         console.log('This is our err: ', err);
         assert(!err);
         assert(Array.isArray(data));


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Schema name should be in PascalCase.
Fixes Postgres failure in https://github.com/strongloop/loopback-datasource-juggler/pull/1819
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
