### PR TITLE
fix: `DEFAULT` for null values in where clause

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -644,10 +644,10 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
         if (Array.isArray(expression)) {
           // Column value is a list
           for (let j = 0, m = expression.length; j < m; j++) {
-            columnValue.push(this.toColumnValue(p, expression[j]));
+            columnValue.push(this.toColumnValue(p, expression[j], true));
           }
         } else {
-          columnValue.push(this.toColumnValue(p, expression));
+          columnValue.push(this.toColumnValue(p, expression, true));
         }
         if (operator === 'between') {
           // BETWEEN v1 AND v2
@@ -669,7 +669,7 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
         // do not coerce RegExp based on property definitions
         columnValue = expression;
       } else {
-        columnValue = this.toColumnValue(p, expression);
+        columnValue = this.toColumnValue(p, expression, true);
       }
       sqlExp = self.buildExpression(columnName, operator, columnValue, p);
       stmt.merge(sqlExp);
@@ -711,13 +711,15 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
  * Convert property name/value to an escaped DB column value
  * @param {Object} prop Property descriptor
  * @param {*} val Property value
+ * @param {boolean} isWhereClause
  * @returns {*} The escaped value of DB column
  */
-PostgreSQL.prototype.toColumnValue = function(prop, val) {
+PostgreSQL.prototype.toColumnValue = function(prop, val, isWhereClause) {
   if (val == null) {
     // PostgreSQL complains with NULLs in not null columns
     // If we have an autoincrement value, return DEFAULT instead
-    if (prop.autoIncrement || prop.id) {
+    // Do not return 'DEFAULT' for id field in where clause
+    if (prop.autoIncrement || (prop.id && !isWhereClause)) {
       return new ParameterizedSQL('DEFAULT');
     } else {
       return null;


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-connector-postgresql/issues/407

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
