### PR TITLE
Fix serialization of arrays of string in update queries values.

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -766,6 +766,10 @@ PostgreSQL.prototype.toColumnValue = function(prop, val, isWhereClause) {
     });
   }
 
+  if (prop.type instanceof Array && prop.type[0] === String) {
+    return JSON.stringify(val);
+  }
+
   return val;
 };
 

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -820,6 +820,53 @@ describe('Serial properties', function() {
   });
 });
 
+describe('Updating of array properties', function() {
+  let db;
+
+  before(function() {
+    db = global.getSchema();
+  });
+
+  it('should return a valid array', function(done) {
+    const schema =
+      {
+        'name': 'TestWithArray',
+        'properties': {
+          'id': {
+            'type': 'number', 'id': true, 'generated': true,
+          },
+          'productCodes': {
+            'type': ['string'],
+          },
+        },
+      };
+    const models = db.modelBuilder.buildModels(schema);
+    const Model = models['TestWithArray'];
+    const count = 0;
+    Model.attachTo(db);
+
+    db.automigrate(function(err, data) {
+      async.series([
+        function(callback) {
+          Model.destroyAll(callback);
+        },
+        function(callback) {
+          Model.create({productCodes: ['AA', 'AB']}, callback);
+        },
+        function(callback) {
+          Model.updateAll({where: {id: 1}}, {productCodes: ['AA', 'AC']}, callback);
+        },
+        function(callback) {
+          Model.findOne({where: {id: 1}}, function(err, r) {
+            r.should.have.property('productCodes');
+            callback(null, r);
+          });
+        },
+      ], done);
+    });
+  });
+});
+
 const data = [
   {
     id: 1,


### PR DESCRIPTION
This pull request fixes a bug I encountered with the PostgeSQL connector when updating the value of a model's property of type array of strings.

When creating the model no issue occurs but when updating it the value stored in the column turns into an invalid array, for example `'{ "A","B","C"}'` instead of `'["A","B","C"]`. After a bit of investigating I  thought it was linked to the juggler giving the value in the query as an `Array` instead of a  `List` object but even after fixing this the issue was still there. So I figured that it must be in the connector and changed it there. 

If you think this change belong somewhere else just tell me and I'll move it.

The added unit test just check that the object is still deserialisable after an update. It fails without the change and pass with it.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈  (done) 

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
