### PR TITLE
Fix serialization of arrays of string in update

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -766,6 +766,24 @@ PostgreSQL.prototype.toColumnValue = function(prop, val, isWhereClause) {
     });
   }
 
+  if (Array.isArray(prop.type)) {
+    // There is two possible cases for the type of "val" as well as two cases for dataType
+    const isArrayDataType = prop.postgresql && prop.postgresql.dataType === 'varchar[]';
+    if (Array.isArray(val)) {
+      if (isArrayDataType) {
+        return val;
+      } else {
+        return JSON.stringify(val);
+      }
+    } else {
+      if (isArrayDataType) {
+        return JSON.parse(val);
+      } else {
+        return val;
+      }
+    }
+  }
+
   return val;
 };
 

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -64,6 +64,15 @@ describe('postgresql connector', function() {
       loc: 'GeoPoint',
       created: Date,
       approved: Boolean,
+      tags: {
+        type: ['string'],
+      },
+      categories: {
+        type: ['string'],
+        postgresql: {
+          dataType: 'varchar[]',
+        },
+      },
     });
     created = new Date();
   });
@@ -199,6 +208,59 @@ describe('postgresql connector', function() {
         done();
       });
     });
+  });
+
+  it('should support creating and updating arrays with default dataType', function(done) {
+    let postId;
+    Post.create({title: 'Updating Arrays', content: 'Content', tags: ['AA', 'AB']})
+      .then((post)=> {
+        postId = post.id;
+        post.should.have.property('tags');
+        post.tags.should.be.Array();
+        post.tags.length.should.eql(2);
+        post.tags.should.eql(['AA', 'AB']);
+        return Post.updateAll({where: {id: postId}}, {tags: ['AA', 'AC']});
+      })
+      .then(()=> {
+        return Post.findOne({where: {id: postId}});
+      })
+      .then((post)=> {
+        post.should.have.property('tags');
+        post.tags.should.be.Array();
+        post.tags.length.should.eql(2);
+        post.tags.should.eql(['AA', 'AC']);
+        done();
+      })
+      .catch((error) => {
+        done(error);
+      });
+  });
+
+  it('should support creating and updating arrays with "varchar[]" dataType', function(done) {
+    let postId;
+    Post.create({title: 'Updating Arrays', content: 'Content', categories: ['AA', 'AB']})
+      .then((post)=> {
+        postId = post.id;
+        post.should.have.property('categories');
+        post.should.have.property('categories');
+        post.categories.should.be.Array();
+        post.categories.length.should.eql(2);
+        post.categories.should.eql(['AA', 'AB']);
+        return Post.updateAll({where: {id: postId}}, {categories: ['AA', 'AC']});
+      })
+      .then(()=> {
+        return Post.findOne({where: {id: postId}});
+      })
+      .then((post)=> {
+        post.should.have.property('categories');
+        post.categories.should.be.Array();
+        post.categories.length.should.eql(2);
+        post.categories.should.eql(['AA', 'AC']);
+        done();
+      })
+      .catch((error) => {
+        done(error);
+      });
   });
 
   it('should support boolean types with false value', function(done) {


### PR DESCRIPTION
This pull request fixes a bug I encountered with the PostgeSQL connector when updating the value of a model's property of type array of strings.

When creating the model no issue occurs but when updating it the value stored in the column turns into an invalid array, for example '{ "A","B","C"}' instead of '["A","B","C"]. After a bit of investigating I thought it was linked to the juggler giving the value in the query as an Array instead of a List object but even after fixing this the issue was still there. So I figured that it must be in the connector and changed it there. (This may be related to #342)

If you think this change belong somewhere else just tell me and I'll move it.

The added unit test just check that the object is still deserialisable after an update. It fails without the change and pass with it.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈 (done)

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
