### PR TITLE
[SEMVER-MAJOR]: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "juggler-v4": "file:./deps/juggler-v4",
     "lodash": "^4.17.4",
     "loopback-datasource-juggler": "^3.0.0 || ^4.0.0",
-    "mocha": "^6.1.4",
+    "mocha": "^7.1.1",
     "rc": "^1.0.0",
     "should": "^13.2.3",
-    "sinon": "^7.3.2"
+    "sinon": "^9.0.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "loopback-connector": "^4.10.2",
-    "pg": "^7.0.0",
+    "pg": "^8.0.2",
     "strong-globalize": "^6.0.0",
     "uuid": "^7.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "setup.sh"
   ],
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^3.2.0",
     "bluebird": "^3.4.6",
-    "chalk": "^3.0.0",
+    "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "loopback-connector": "^4.10.2",
     "pg": "^7.0.0",
-    "strong-globalize": "^5.0.5",
-    "uuid": "^3.0.1"
+    "strong-globalize": "^6.0.0",
+    "uuid": "^7.0.3"
   },
   "devDependencies": {
     "eslint": "^6.0.1",


### PR DESCRIPTION
**Update dependencies**
 - async to ^3.2
 - chalk to ^4.0
 - uuid to ^7.0

**Upgrade dev dependencies**
 - mocha to ^7.1
 - sinon to ^9.0

**[SEMVER-MAJOR] Upgrade `pg` to `8.0`**

Notable breaking changes:
- Change default behavior when not specifying `rejectUnauthorized` with the SSL connection parameters. Previously we defaulted to `rejectUnauthorized: false` when it was not specifically included. We now default to `rejectUnauthorized: true`. Manually specify `{ ssl: { rejectUnauthorized: false } }` for old behavior.

- Change default database when not specified to use the `user` config option if available. Previously `process.env.USER` was used.

See pg's changelog for the full list of breaking changes.
https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#pg800

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
