### PR TITLE
fix: honor non-unique property constraint

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -823,7 +823,7 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && !type && typeof i === 'object' && i.unique && i.unique === true) {
+        if (!kind && typeof i === 'object' && i.unique && i.unique === true) {
           kind = ' UNIQUE ';
         }
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -823,7 +823,7 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && ((i && typeof i === 'object')? i.unique !== false : true)) {
+        if (!kind && !type && ((i && typeof i === 'object')? i.unique !== false : true)) {
           kind = 'UNIQUE';
         }
 
@@ -852,7 +852,7 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && ((i && typeof i === 'object')? i.unique !== false : true)) {
+        if (!kind && !type && ((i && typeof i === 'object')? i.unique !== false : true)) {
           kind = 'UNIQUE';
         }
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -823,8 +823,8 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && typeof i === 'object' && i.unique && i.unique === true) {
-          kind = ' UNIQUE ';
+        if (!kind && ((i && typeof i === 'object')? i.unique !== false : true)) {
+          kind = 'UNIQUE';
         }
 
         sql.push('CREATE ' + kind + ' INDEX ' + self.escapeName(iName) + ' ON ' + self.tableEscaped(model) +
@@ -852,8 +852,8 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && typeof i === 'object' && i.unique && i.unique === true) {
-          kind = ' UNIQUE ';
+        if (!kind && ((i && typeof i === 'object')? i.unique !== false : true)) {
+          kind = 'UNIQUE';
         }
 
         sql.push('CREATE ' + kind + ' INDEX ' + iName + ' ON ' + self.tableEscaped(model) +

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -823,7 +823,7 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (!kind && !type && typeof i === 'object' || i.unique && i.unique === true) {
+        if (!kind && !type && typeof i === 'object' && i.unique && i.unique === true) {
           kind = ' UNIQUE ';
         }
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -852,7 +852,7 @@ function mixinMigration(PostgreSQL) {
           kind = i.kind;
         }
 
-        if (i.options && i.options.unique && i.options.unique === true) {
+        if (!kind && typeof i === 'object' && i.unique && i.unique === true) {
           kind = ' UNIQUE ';
         }
 


### PR DESCRIPTION
Fixes: Fix - fail to honor non-unique property constraint #389

Connector does not honor non-unique constraint definition for a property declaration in model json file on automigrate.  
Example model json file snipet:
```
"properties": [ 
  "email": {
    "type": "String",
    "index": {
      "unique": false
    }
  }
]

OR

"indexes": [
  "email_ndx" {
    "keys": [ "email" ],
    "options": {
      "unique": false
    }
  }
]
```

error generated: "could not create unique index "[modelname] _email_idx"