### PR TITLE
docs: update readme with more lb4 form and hide lb3 form

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,32 @@ In your application root directory, enter this command to install the connector:
 $ npm install loopback-connector-postgresql --save
 ```
 
-This installs the module from npm and adds it as a dependency to the application's `package.json` file.
+This installs the module from npm and adds it as a dependency to the application's `package.json` file.
 
 If you create a PostgreSQL data source using the data source generator as described below, you don't have to do this, since the generator will run `npm install` for you.
 
 ## Creating a data source
 
-Use the [Data source generator](http://loopback.io/doc/en/lb3/Data-source-generator.html) to add a PostgreSQL data source to your application.  
+For LoopBack 4 users, use the LoopBack 4 [Command-line interface](https://loopback.io/doc/en/lb4/Command-line-interface.html) to generate a DataSource with PostgreSQL connector to your LB4 application. Run [`lb4 datasource`](https://loopback.io/doc/en/lb4/DataSource-generator.html), it will prompt for configurations such as host, post, etc. that are required to connect to a PostgreSQL database.
+
+After setting it up, the configuration can be found under `src/datasources/<DataSourceName>.datasource.ts`, which would look like this:
+
+```ts
+const config = {
+  name: 'db',
+  connector: 'postgresql',
+  url: '',
+  host:'localhost',
+  port: 5432,
+  user: 'user',
+  password: 'pass',
+  database: 'testdb',
+};
+```
+
+<details><summary markdown="span"><strong>For LoopBack 3 users</strong></summary>
+
+Use the [Data source generator](http://loopback.io/doc/en/lb3/Data-source-generator.html) to add a PostgreSQL data source to your application.  
 The generator will prompt for the database server hostname, port, and other settings
 required to connect to a PostgreSQL database. It will also run the `npm install` command above for you.
 
@@ -48,31 +67,31 @@ The entry in the application's `/server/datasources.json` will look like this:
 }
 ```
 
-Edit `datasources.json` to add other properties that enable you to connect the data source to a PostgreSQL database.
+Edit `datasources.json` to add other properties that enable you to connect the data source to a PostgreSQL database.
+
+</details>
 
 ### Connection Pool Settings
 
-You can also specify connection pool settings in `datasources.json`. For instance you can specify the minimum and the maximum pool size, and the maximum pool client's idle time before closing the client.
+You can also specify connection pool settings in `<DataSourceName>.datasource.ts` ( or `datasources.json` for LB3 users). For instance you can specify the minimum and the maximum pool size, and the maximum pool client's idle time before closing the client.
 
-Example of `datasource.json`:
+Example of `db.datasource.ts`:
 
-```
-{
-  "mypostgresdb": {
-    "host": "mydbhost",
-    "port": 5432,
-    "url": "postgres://admin:password1@mydbhost:5432/db1?ssl=false",
-    "database": "db1",
-    "password": "password1",
-    "name": "mypostgresdb",
-    "user": "admin",
-    "connector": "postgresql",
-    "min": 5,
-    "max": 200,
-    "idleTimeoutMillis": 60000,
-    "ssl": false
-  }
-}
+```ts
+const config = {
+  name: 'db',
+  connector: 'postgresql',
+  url: '',
+  host: 'localhost',
+  port: 5432,
+  user: 'user',
+  password: 'pass',
+  database: 'testdb',
+  min: 5,
+  max: 200,
+  idleTimeoutMillis: 60000,
+  ssl: false
+};
 ```
 
 Check out [node-pg-pool](https://github.com/brianc/node-pg-pool) and [node postgres pooling example](https://github.com/brianc/node-postgres#pooling-example) for more information.
@@ -169,22 +188,79 @@ information about configuration parameters, see [node-postgres documentation](ht
 
 A common PostgreSQL configuration is to connect to the UNIX domain socket `/var/run/postgresql/.s.PGSQL.5432` instead of using the TCP/IP port. For example:
 
-```javascript
-{
-  "postgres": {
-    "host": "/var/run/postgresql/",
-    "port": "5432",
-    "database": "dbname",
-    "username": "dbuser",
-    "password": "dbpassword",
-    "name": "postgres",
-    "debug": true,
-    "connector": "postgresql"
+```ts
+const config = {
+  name: 'db',
+  connector: 'postgresql',
+  url: '',
+  host: '/var/run/postgresql/',
+  port: 5432,
+  user: 'user',
+  password: 'pass',
+  database: 'testdb',
+  debug: true
+};
+```
+
+## Defining models
+
+LoopBack allows you to specify some database settings through the model definition and/or the property definition. These definitions would be mapped to the database. Please check out the CLI [`lb4 model`](https://loopback.io/doc/en/lb4/Model-generator.html) for generating LB4 models. The following is a typical LoopBack 4 model that specifies the schema, table and column details through model definition and property definitions:
+
+```ts
+@model({
+  settings: { postgresql: { schema: 'public', table: 'inventory'} },
+})
+export class Inventory extends Entity {
+  @property({
+    type: 'number',
+    required: true,
+    scale: 0,
+    id: 1,
+    postgresql: {
+      columnName: 'id',
+      dataType: 'integer',
+      dataLength: null,
+      dataPrecision: null,
+      dataScale: 0,
+      nullable: 'NO',
+    },
+  })
+  id: number;
+
+  @property({
+    type: 'string',
+    postgresql: {
+      columnName: 'name',
+      dataType: 'text',
+      dataLength: null,
+      dataPrecision: null,
+      dataScale: null,
+      nullable: 'YES',
+    },
+  })
+  name?: string;
+
+  @property({
+    type: 'boolean',
+    required: true,
+    postgresql: {
+      columnName: 'available',
+      dataType: 'boolean',
+      dataLength: null,
+      dataPrecision: null,
+      dataScale: null,
+      nullable: 'NO',
+    },
+  })
+  available: boolean;
+
+  constructor(data?: Partial<User>) {
+    super(data);
   }
 }
 ```
 
-## Defining models
+<details><summary markdown="span"><strong>For LoopBack 3 users</strong></summary>
 
 The model definition consists of the following properties.
 
@@ -311,9 +387,13 @@ For example:
 }
 ```
 
+</details>
+
+To learn more about specifying database settings, please check the section [Data Mapping Properties](https://loopback.io/doc/en/lb4/Model.html#data-mapping-properties).
+
 ## Type mapping
 
-See [LoopBack types](http://loopback.io/doc/en/lb3/LoopBack-types.html) for details on LoopBack's data types.
+See [LoopBack types](http://loopback.io/doc/en/lb3/LoopBack-types.html) for details on LoopBack's data types.
 
 ### LoopBack to PostgreSQL types
 
@@ -347,6 +427,37 @@ See [LoopBack types](http://loopback.io/doc/en/lb3/LoopBack-types.html) for de
   </tbody>
 </table>
 
+Besides the basic LoopBack types, as we introduced above, you can also specify the database type for model properties. It would be mapped to the database (see [Data Mapping Properties](https://loopback.io/doc/en/lb4/Model.html#data-mapping-properties)). For example, we would like the property `price` to have database type `double precision` in the corresponding table in the database, we have specify it as following:
+
+```ts
+  @property({
+    type: 'number',
+    postgresql: {
+      dataType: 'double precision',
+    },
+  })
+  price?: number;
+```
+
+<details><summary markdown="span"><strong>For LoopBack 3 users</strong></summary>
+
+```javascript
+"properties": {
+    // ..
+    "price": {
+      "type": "Number",
+      "postgresql": {
+        "dataType": "double precision",
+      }
+    },
+```
+
+</details>
+
+{% include warning.html content="
+Not all database types are supported for operating CRUD operations and queries with filters. For example, type Array cannot be filtered correctly, see GitHub issues: [# 441](https://github.com/strongloop/loopback-connector-postgresql/issues/441) and [# 342](https://github.com/strongloop/loopback-connector-postgresql/issues/342).
+" %}
+
 ### PostgreSQL types to LoopBack
 
 <table>
@@ -372,7 +483,7 @@ See [LoopBack types](http://loopback.io/doc/en/lb3/LoopBack-types.html) for de
       <td>Node.js <a href="http://nodejs.org/api/buffer.html">Buffer object</a></td>
     </tr>
     <tr>
-      <td>SMALLINT<br>INTEGER<br>BIGINT<br>DECIMAL<br>NUMERIC<br>REAL<br>DOUBLE<br>SERIAL<br>BIGSERIAL</td>
+      <td>SMALLINT<br>INTEGER<br>BIGINT<br>DECIMAL<br>NUMERIC<br>REAL<br>DOUBLE PRECISION<br>FLOAT<br>SERIAL<br>BIGSERIAL</td>
       <td>Number</td>
     </tr>
     <tr>
@@ -398,28 +509,24 @@ For details, see the corresponding [driver issue](https://github.com/brianc/node
 
 Assuming a model such as this:
 
-```json
-{
-  "name": "Customer",
-  "properties": {
-    "address": {
-      "type": "object",
-      "postgresql": {
-        "dataType": "json"
-      }
-    }
-  }
-}
+```ts
+  @property({
+    type: 'number',
+    postgresql: {
+      dataType: 'double precision',
+    },
+  })
+  price?: number;
 ```
 
 You can query the nested fields with dot notation:
 
-```javascript
-Customer.find({
+```ts
+CustomerRepository.find({
   where: {
-    "address.state": "California"
+    address.state: 'California',
   },
-  order: "address.city"
+  order: 'address.city',
 });
 ```
 
@@ -428,34 +535,87 @@ Customer.find({
 ### Model discovery
 
 The PostgreSQL connector supports _model discovery_ that enables you to create LoopBack models
-based on an existing database schema using the unified [database discovery API](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-discoverandbuildmodels). For more information on discovery, see [Discovering models from relational databases](https://loopback.io/doc/en/lb3/Discovering-models-from-relational-databases.html).
+based on an existing database schema. Once you defined your datasource:
+-  LoopBack 4 users could use the commend [`lb4 discover`](https://loopback.io/doc/en/lb4/Discovering-models.html) to discover models. 
+- For LB3 users, please check [Discovering models from relational databases](https://loopback.io/doc/en/lb3/Discovering-models-from-relational-databases.html). 
+
+(See [database discovery API](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-discoverandbuildmodels) for related APIs information)
 
 ### Auto-migration
 
 The PostgreSQL connector also supports _auto-migration_ that enables you to create a database schema
-from LoopBack models using the [LoopBack automigrate method](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-automigrate).
+from LoopBack models.
 
-For more information on auto-migration, see [Creating a database schema from models](https://loopback.io/doc/en/lb3/Creating-a-database-schema-from-models.html) for more information.
+For example, based on the following model, the auto-migration method would create/alter existing `customer` table under `public` schema in the database. Table `customer` would have two columns: `name` and `id`, where `id` is also the primary key and has the default value `SERIAL` as it has definition of `type: 'Number'` and `generated: true`:
 
-LoopBack PostgreSQL connector creates the following schema objects for a given
-model: a table, for example, PRODUCT under the 'public' schema within the database.
+```ts
+@model()
+export class Customer extends Entity {
+  @property({
+    id: true,
+    type: 'Number',
+    required: false
+  })
+  id: number;
 
-The auto-migrate method:
+  @property({
+    type: 'string'
+  })
+  name: string;
+}
+```
 
-- Defines a primary key for the properties whose `id` property is true (or a positive number).
-- Creates a column with 'SERIAL' type if the `generated` property of the `id` property is true.
+By default, tables generated by the auto-migration are under `public` schema and named in lowercase.
 
-Destroying models may result in errors due to foreign key integrity. First delete any related models by calling delete on models with relationships.
+Besides the basic model metadata, LoopBack allows you to specify part of the database schema definition via the
+property definition, which would be mapped to the database.
+
+For example, based on the following model, after running the auto-migration script, a table named `CUSTOMER` under schema `market` will be created. Moreover, you can also have different names for your property and the corresponding column. In the example, by specifying the column name, the property `name` will be mapped to the `customer_name` column. This is useful when your database has a different naming convention than LoopBack (camelCase).
+
+```ts
+@model(
+  settings: {
+    postgresql: {schema: 'market', table: 'CUSTOMER'},
+  }
+)
+export class Customer extends Entity {
+  @property({
+    id: true,
+    type: 'Number',
+    required: false
+  })
+  id: number;
+
+  @property({
+    type: 'string',
+    postgresql: {
+      columnName: 'customer_name'
+    }
+  })
+  name: string;
+}
+```
+
+For how to run the script and more details:
+- For LB4 users, please check [Database Migration](https://loopback.io/doc/en/lb4/Database-migrations.html)
+- For LB3 users, please check [Creating a database schema from models](https://loopback.io/doc/en/lb3/Creating-a-database-schema-from-models.html)
+
+(See [LoopBack auto-migrate method](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-automigrate) for related APIs information)
+
+Here are some limitations and tips:
+
+- If you defined `generated: true` in the id property, it generates integers by default. For auto-generated uuid, see [Auto-generated id property](#auto-generated-id-property)
+- Only the id property supports the auto-generation setting `generated: true` for now
+- Auto-migration doesn't create foreign key constraints by default. But they can be defined through the model definition. See [Auto-migrate with foreign keys](#auto-migrateauto-update-models-with-foreign-keys)
+- Destroying models may result in errors due to foreign key integrity. First delete any related models by calling delete on models with relationships.
 
 ### Auto-migrate/Auto-update models with foreign keys
 
-Foreign key constraints can be defined in the model `options`. Removing or updating the value of `foreignKeys` will be updated or delete or update the constraints in the db tables.
-
-If there is a reference to an object being deleted then the `DELETE` will fail. Likewise if there is a create with an invalid FK id then the `POST` will fail.
+Foreign key constraints can be defined in the model definition. 
 
 **Note**: The order of table creation is important. A referenced table must exist before creating a foreign key constraint.
 
-For **LoopBack 4** users, define your models under the `models/` folder as follows:
+Define your models and the foreign key constraints as follows:
 
 `customer.model.ts`:
 
@@ -465,14 +625,12 @@ export class Customer extends Entity {
   @property({
     id: true,
     type: 'Number',
-    required: false,
-    length: 20
+    required: false
   })
   id: number;
 
   @property({
-    type: 'string',
-    length: 20
+    type: 'string'
   })
   name: string;
 }
@@ -481,31 +639,38 @@ export class Customer extends Entity {
 `order.model.ts`:
 
 ```ts
-@model()
+@model({
+  settings: {
+    foreignKeys: {
+      fk_order_customerId: {
+        name: 'fk_order_customerId',
+        entity: 'Customer',
+        entityKey: 'id',
+        foreignKey: 'customerId',
+      },
+    },
+  })
 export class Order extends Entity {
   @property({
     id: true,
     type: 'Number',
-    required: false,
-    length: 20
+    required: false
   })
   id: number;
 
   @property({
-    type: 'string',
-    length: 20
+    type: 'string'
   })
   name: string;
 
   @property({
-    type: 'Number',
-    length: 20
+    type: 'Number'
   })
   customerId: number;
 }
 ```
 
-For **LoopBack 3** users, you can define your model JSON schema as follows:
+<details><summary markdown="span"><strong>For LoopBack 3 users</strong></summary>
 
 ```json
 ({
@@ -516,13 +681,11 @@ For **LoopBack 3** users, you can define your model JSON schema as follows:
   "properties": {
     "id": {
       "type": "Number",
-      "length": 20,
       "id": 1
     },
     "name": {
       "type": "String",
-      "required": false,
-      "length": 40
+      "required": false
     }
   }
 },
@@ -541,24 +704,29 @@ For **LoopBack 3** users, you can define your model JSON schema as follows:
   },
   "properties": {
     "id": {
-      "type": "Number",
-      "length": 20,
+      "type": "Number"
       "id": 1
     },
     "customerId": {
-      "type": "Number",
-      "length": 20
+      "type": "Number"
     },
     "description": {
       "type": "String",
-      "required": false,
-      "length": 40
+      "required": false
     }
   }
 })
 ```
 
-Auto-migrate supports the automatic generation of property values. For PostgreSQL, the default id type is _integer_. If you have `generated: true` in the id property, it generates integers by default:
+</details>
+<br>
+{% include tips.html content="
+Removing or updating the value of `foreignKeys` will be updated or delete or update the constraints in the db tables. If there is a reference to an object being deleted then the `DELETE` will fail. Likewise if there is a create with an invalid FK id then the `POST` will fail.
+" %}
+
+### Auto-generated id property
+
+Auto-migrate supports the automatic generation of property values for the id property. For PostgreSQL, the default id type is _integer_. Thus if you have `generated: true` in the id property, it generates integers by default:
 
 ```ts
 {
@@ -611,13 +779,12 @@ WARNING: It is the users' responsibility to make sure the provided extension and
 
 This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) policy, with the following End Of Life (EOL) dates:
 
-| Version    | Status          | Published | EOL                  |
-| ---------- | --------------- | --------- | -------------------- |
-| 5.x        | Current         | Apr 2020  | Apr 2023 _(minimum)_ |
-| 3.x        | Active LTS      | Mar 2017  | Apr 2022             |
+| Version | Status     | Published | EOL                  |
+| ------- | ---------- | --------- | -------------------- |
+| 5.x     | Current    | Apr 2020  | Apr 2023 _(minimum)_ |
+| 3.x     | Active LTS | Mar 2017  | Apr 2022             |
 
 Learn more about our LTS plan in [docs](https://loopback.io/doc/en/contrib/Long-term-support.html).
-
 
 ## Running tests
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
While working on https://github.com/strongloop/loopback-next/issues/4877, I realized that the PostgreSQL connector overview we have in LB4 site is not a good fit as:
- LB4 uses different cli to generate the datasource
- LB4 has different way to define models
- LB4 code are mainly written in Tsc
- LB4 doesn't have all options use in LB3

Inspired by markdown collapsible section, I think we can fold the LB3 content and mainly display the LB4 in these connector README docs
<details>
  <summary><strong>Click to expand!</strong></summary>
  
  Since we are using one doc for 2 different versions.
  And (hopefully) less people are using LB3
</details>

**Edit:**
Besides the collapsible block, I also update the auto-migration/discovery part.

The following is part of the preview of the collapsible section from my changes:

<img width="827" alt="Screen Shot 2020-05-22 at 17 41 47" src="https://user-images.githubusercontent.com/50331796/82712489-11ebad80-9c56-11ea-8a0e-fbef08e64f51.png">
                               :arrow_down::arrow_down::arrow_down:
<img width="875" alt="Screen Shot 2020-05-22 at 17 41 55" src="https://user-images.githubusercontent.com/50331796/82712493-144e0780-9c56-11ea-85f8-22fdf12ecbf3.png">

========================

<img width="863" alt="Screen Shot 2020-05-22 at 17 43 15" src="https://user-images.githubusercontent.com/50331796/82712513-1ca64280-9c56-11ea-8947-cbb51ed03e04.png">
                                 :arrow_down::arrow_down::arrow_down:
<img width="838" alt="Screen Shot 2020-05-22 at 17 43 20" src="https://user-images.githubusercontent.com/50331796/82712515-1e700600-9c56-11ea-9cf2-163ef712294e.png">

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
