### PR TITLE
fix: use tip.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ export class Order extends Entity {
 
 </details>
 <br>
-{% include tips.html content="
+{% include tip.html content="
 Removing or updating the value of `foreignKeys` will be updated or delete or update the constraints in the db tables. If there is a reference to an object being deleted then the `DELETE` will fail. Likewise if there is a create with an invalid FK id then the `POST` will fail.
 " %}
 


### PR DESCRIPTION
In the Travis job running on loopback.io, it has errors:
```
  Liquid Exception: Could not locate the included file 'tips.html' in any of ["/home/travis/build/strongloop/loopback.io/_includes", "/home/travis/.rvm/gems/ruby-2.5.3/gems/jekyll-theme-primer-0.5.4/_includes"]. Ensure it exists in one of those directories and is not a symlink as those are not allowed in safe mode. in /_layouts/readme.html
```

`tips.html` referenced in this README should be `tip.html`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
