### PR TITLE
Add on delete options on FK constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,8 @@ export class Customer extends Entity {
         entity: 'Customer',
         entityKey: 'id',
         foreignKey: 'customerId',
+        onDelete: 'CASCADE',
+        onUpdate: 'SET NULL'
       },
     },
   })
@@ -764,7 +766,9 @@ export class Order extends Entity {
         "name": "fk_order_customerId",
         "entity": "Customer",
         "entityKey": "id",
-        "foreignKey": "customerId"
+        "foreignKey": "customerId",
+        "onDelete": "CASCADE",
+        "onUpdate": "SET NULL"
       }
     }
   },
@@ -787,7 +791,7 @@ export class Order extends Entity {
 </details>
 <br>
 {% include tip.html content="
-Removing or updating the value of `foreignKeys` will be updated or delete or update the constraints in the db tables. If there is a reference to an object being deleted then the `DELETE` will fail. Likewise if there is a create with an invalid FK id then the `POST` will fail.
+Removing or updating the value of `foreignKeys` will be updated or delete or update the constraints in the db tables. If there is a reference to an object being deleted then the `DELETE` will fail. Likewise if there is a create with an invalid FK id then the `POST` will fail. The `onDelete` and `onUpdate` properties are optional and will default to `NO ACTION`.
 " %}
 
 ### Auto-generated ids

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -263,6 +263,7 @@ function mixinDiscovery(PostgreSQL) {
     let sql =
       'SELECT tc.table_schema AS "fkOwner", tc.constraint_name AS "fkName", tc.table_name AS "fkTableName",'
       + ' kcu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",'
+      + ' rcu.delete_rule AS "onDelete", rcu.update_rule AS "onUpdate",'
       + ' ccu.table_schema AS "pkOwner",'
       + ' (SELECT constraint_name'
       + ' FROM information_schema.table_constraints tc2'
@@ -273,6 +274,8 @@ function mixinDiscovery(PostgreSQL) {
       + ' ON tc.constraint_schema = kcu.constraint_schema AND tc.constraint_name = kcu.constraint_name'
       + ' JOIN information_schema.constraint_column_usage ccu'
       + ' ON ccu.constraint_schema = tc.constraint_schema AND ccu.constraint_name = tc.constraint_name'
+      + ' JOIN information_schema.referential_constraints AS rcu'
+      + ' ON rcu.constraint_name  = tc.constraint_name'
       + ' WHERE tc.constraint_type = \'FOREIGN KEY\'';
     if (owner) {
       sql += ' AND tc.table_schema=\'' + owner + '\'';
@@ -300,6 +303,7 @@ function mixinDiscovery(PostgreSQL) {
   PostgreSQL.prototype.buildQueryExportedForeignKeys = function(owner, table) {
     let sql = 'SELECT kcu.constraint_name AS "fkName", kcu.table_schema AS "fkOwner", kcu.table_name AS "fkTableName",'
       + ' kcu.column_name AS "fkColumnName", kcu.ordinal_position AS "keySeq",'
+      + ' rcu.delete_rule AS "onDelete", rcu.update_rule AS "onUpdate",'
       + ' (SELECT constraint_name'
       + ' FROM information_schema.table_constraints tc2'
       + ' WHERE tc2.constraint_type = \'PRIMARY KEY\' and tc2.table_name=ccu.table_name limit 1) AS "pkName",'
@@ -308,6 +312,8 @@ function mixinDiscovery(PostgreSQL) {
       + ' information_schema.constraint_column_usage ccu'
       + ' JOIN information_schema.key_column_usage kcu'
       + ' ON ccu.constraint_schema = kcu.constraint_schema AND ccu.constraint_name = kcu.constraint_name'
+      + ' JOIN information_schema.referential_constraints AS rcu'
+      + ' ON rcu.constraint_name  = tc.constraint_name'
       + ' WHERE kcu.position_in_unique_constraint IS NOT NULL';
     if (owner) {
       sql += ' and ccu.table_schema=\'' + owner + '\'';

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -574,7 +574,9 @@ function mixinMigration(PostgreSQL) {
           const fkRefTable = self.table(fkEntityName);
           needsToDrop = !isCaseInsensitiveEqual(fkCol, fk.fkColumnName) ||
                         !isCaseInsensitiveEqual(fkRefKey, fk.pkColumnName) ||
-                        !isCaseInsensitiveEqual(fkRefTable, fk.pkTableName);
+                        !isCaseInsensitiveEqual(fkRefTable, fk.pkTableName) ||
+                        parseAction(newFk.onDelete) != fk.onDelete ||
+                        parseAction(newFk.onUpdate) != fk.onUpdate;
         } else {
           // FK will be dropped if column is removed
           // only if FK is in model properties then need to drop
@@ -636,12 +638,28 @@ function mixinMigration(PostgreSQL) {
       // verify that the other model in the same DB
       if (this._models[fkEntityName]) {
         return 'CONSTRAINT ' + this.escapeName(fk.name) + ' ' +
-          'FOREIGN KEY (' + this.escapeName(fk.foreignKey) + ') ' +
-          'REFERENCES ' + this.tableEscaped(fkEntityName) + '(' + fk.entityKey + ')';
+        'FOREIGN KEY (' + this.escapeName(fk.foreignKey) + ') ' +
+        'REFERENCES ' + this.tableEscaped(fkEntityName) + '(' + fk.entityKey + ') ' +
+        'ON DELETE ' + parseAction(fk.onDelete) + ' ' +
+        'ON UPDATE ' + parseAction(fk.onUpdate);
       }
     }
     return '';
   };
+
+  /*!
+   * Process model settings foreign key action,
+   * if action is not a valid sql action return 'NO ACTION'
+   * @param {Any} action
+   */
+  function parseAction(action) {
+    if (typeof action !== 'string') return 'NO ACTION';
+    const _action = action.toUpperCase();
+    if (['RESTRICT', 'CASCADE', 'SET NULL', 'SET DEFAULT'].includes(_action))
+      return _action;
+    else
+      return 'NO ACTION';
+  }
 
   /*!
    * Case insensitive comparison of two strings

--- a/test/postgresql.autoupdate.test.js
+++ b/test/postgresql.autoupdate.test.js
@@ -469,6 +469,8 @@ describe('autoupdate', function() {
               'entity': 'Product',
               'entityKey': 'id',
               'foreignKey': 'productId',
+              'onDelete': 'CASCADE',
+              'onUpdate': 'SET NULL',
             },
           },
         },
@@ -578,6 +580,8 @@ describe('autoupdate', function() {
               assert.equal(foreignKeys[0].pkTableName, 'customer_test2');
               assert.equal(foreignKeys[0].fkColumnName, 'customerId');
               assert.equal(foreignKeys[0].fkName, 'fk_ordertest_customerId');
+              assert.equal(foreignKeys[0].onDelete, 'NO ACTION');
+              assert.equal(foreignKeys[0].onUpdate, 'NO ACTION');
 
               // update the fk of model OrderTest from customerId to productId
               // productId refers to model Product
@@ -596,6 +600,8 @@ describe('autoupdate', function() {
                   assert.equal(foreignKeys[0].pkTableName, 'product_test');
                   assert.equal(foreignKeys[0].fkColumnName, 'productId');
                   assert.equal(foreignKeys[0].fkName, 'fk_ordertest_productId');
+                  assert.equal(foreignKeys[0].onDelete, 'CASCADE');
+                  assert.equal(foreignKeys[0].onUpdate, 'SET NULL');
 
                   // remove fk from model OrderTest
                   ds.createModel(orderTest_schema_v3.name, orderTest_schema_v3.properties,


### PR DESCRIPTION
Allow setting `on delete` rule on foreign key constraints.
Update foreign key discovery query to add on delete rules mainly for testing purpose.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html) 
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
