### PR TITLE
array_type_field_filter: Add new contains filter to search on Array type field

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const config = {
 
 <details><summary markdown="span"><strong>For LoopBack 3 users</strong></summary>
 
-Use the [Data source generator](http://loopback.io/doc/en/lb3/Data-source-generator.html) to add a PostgreSQL data source to your application.  
+Use the [Data source generator](http://loopback.io/doc/en/lb3/Data-source-generator.html) to add a PostgreSQL data source to your application.
 The generator will prompt for the database server hostname, port, and other settings
 required to connect to a PostgreSQL database. It will also run the `npm install` command above for you.
 
@@ -96,7 +96,7 @@ const config = {
 
 Check out [node-pg-pool](https://github.com/brianc/node-pg-pool) and [node postgres pooling example](https://github.com/brianc/node-postgres#pooling-example) for more information.
 
-### Properties
+### Configuration options
 
 <table>
   <thead>
@@ -106,7 +106,7 @@ Check out [node-pg-pool](https://github.com/brianc/node-pg-pool) and [node postg
       <th>Description</th>
     </tr>
   </thead>
-    <tbody>    
+    <tbody>
     <tr>
       <td>connector</td>
       <td>String</td>
@@ -176,6 +176,14 @@ Check out [node-pg-pool](https://github.com/brianc/node-pg-pool) and [node postg
       <td>Boolean/String</td>
       <td>Set to <code>false</code> to disable default sorting on <code>id</code> column(s). Set to <code>numericIdOnly</code> to only apply to IDs with a number type <code>id</code>.</td>
     </tr>
+    <tr>
+      <td>allowExtendedOperators</td>
+      <td>Boolean</td>
+      <td>Set to <code>true</code> to enable PostgreSQL-specific operators
+          such as <code>contains</code>. Learn more in
+          <a href="#extended-operators">Extended operators</a> below.
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -201,29 +209,6 @@ const config = {
   debug: true
 };
 ```
-
-
-## Additional properties
-
-<table>
-  <thead>
-  <tr>
-    <th width="160">Property</th>
-    <th width="90">Type</th>
-    <th>Default</th>
-    <th>Description</th>
-  </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>allowExtendedOperators</td>
-      <td>Boolean</td>
-      <td><code>false</code></td>
-      <td>Set to <code>true</code> to enable using Postgres operators such as <code>contains</code> which is used to perform filter on postgres array type field.</td>
-    </tr>
-  </tbody>
-</table>
-
 
 ## Defining models
 
@@ -295,7 +280,7 @@ The model definition consists of the following properties.
       <th>Description</th>
     </tr>
   </thead>
-  <tbody>    
+  <tbody>
     <tr>
       <td>name</td>
       <td>Camel-case of the database table name</td>
@@ -560,34 +545,56 @@ CustomerRepository.find({
 });
 ```
 
-## Querying Postgres Array type fields
+## Extended operators
 
-**Note** The fields you are querying should be setup to use the  postgresql array data type - see Defining models
+PostgreSQL supports the following PostgreSQL-specific operators:
+
+- [`contains`](#operator-contains)
+
+Please note extended operators are disabled by default, you must enable
+them at datasource level or model level by setting `allowExtendedOperators` to
+`true`.
+
+### Operator `contains`
+
+The `contains` operator allow you to query array properties and pick only
+rows where the stored value contains all of the items specified by the query.
+
+The operator is implemented using PostgreSQL [array operator
+`@>`](https://www.postgresql.org/docs/current/functions-array.html).
+
+**Note** The fields you are querying must be setup to use the postgresql array data type - see [Defining models](#defining-models) above.
 
 Assuming a model such as this:
 
 ```ts
+@model({
+  settings: {
+    allowExtendedOperators: true,
+  }
+})
+class Post {
   @property({
     type: ['string'],
     postgresql: {
-          dataType: 'varchar[]',
-        },
+      dataType: 'varchar[]',
+    },
   })
   categories?: string[];
+}
 ```
 
-You can query the tags fields via setting allowExtendedOperators to true
+You can query the tags fields as follows:
 
 ```ts
-Model.dataSource.settings.allowExtendedOperators = true;
-    const post = await Post.find({where: {
-        {
-          categories: {'contains': ['AA']},
-        }
-      }
-    });
+const posts = await postRepository.find({
+  where: {
+    {
+      categories: {'contains': ['AA']},
+    }
+  }
+});
 ```
-
 
 ## Discovery and auto-migration
 
@@ -595,8 +602,8 @@ Model.dataSource.settings.allowExtendedOperators = true;
 
 The PostgreSQL connector supports _model discovery_ that enables you to create LoopBack models
 based on an existing database schema. Once you defined your datasource:
--  LoopBack 4 users could use the commend [`lb4 discover`](https://loopback.io/doc/en/lb4/Discovering-models.html) to discover models. 
-- For LB3 users, please check [Discovering models from relational databases](https://loopback.io/doc/en/lb3/Discovering-models-from-relational-databases.html). 
+-  LoopBack 4 users could use the commend [`lb4 discover`](https://loopback.io/doc/en/lb4/Discovering-models.html) to discover models.
+- For LB3 users, please check [Discovering models from relational databases](https://loopback.io/doc/en/lb3/Discovering-models-from-relational-databases.html).
 
 (See [database discovery API](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-discoverandbuildmodels) for related APIs information)
 
@@ -670,7 +677,7 @@ Here are some limitations and tips:
 
 ### Auto-migrate/Auto-update models with foreign keys
 
-Foreign key constraints can be defined in the model definition. 
+Foreign key constraints can be defined in the model definition.
 
 **Note**: The order of table creation is important. A referenced table must exist before creating a foreign key constraint.
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,29 @@ const config = {
 };
 ```
 
+
+## Additional properties
+
+<table>
+  <thead>
+  <tr>
+    <th width="160">Property</th>
+    <th width="90">Type</th>
+    <th>Default</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>allowExtendedOperators</td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Set to <code>true</code> to enable using Postgres operators such as <code>contains</code> which is used to perform filter on postgres array type field.</td>
+    </tr>
+  </tbody>
+</table>
+
+
 ## Defining models
 
 LoopBack allows you to specify some database settings through the model definition and/or the property definition. These definitions would be mapped to the database. Please check out the CLI [`lb4 model`](https://loopback.io/doc/en/lb4/Model-generator.html) for generating LB4 models. The following is a typical LoopBack 4 model that specifies the schema, table and column details through model definition and property definitions:
@@ -413,6 +436,12 @@ details on LoopBack's data types.
         Default length is 1024
       </td>
     </tr>
+     <tr>
+      <td>String[]</td>
+      <td>
+        VARCHAR2[]
+      </td>
+    </tr>
     <tr>
       <td>Number</td>
       <td>INTEGER</td>
@@ -530,6 +559,35 @@ CustomerRepository.find({
   order: 'address.city',
 });
 ```
+
+## Querying Postgres Array type fields
+
+**Note** The fields you are querying should be setup to use the  postgresql array data type - see Defining models
+
+Assuming a model such as this:
+
+```ts
+  @property({
+    type: ['string'],
+    postgresql: {
+          dataType: 'varchar[]',
+        },
+  })
+  categories?: string[];
+```
+
+You can query the tags fields via setting allowExtendedOperators to true
+
+```ts
+Model.dataSource.settings.allowExtendedOperators = true;
+    const post = await Post.find({where: {
+        {
+          categories: {'contains': ['AA']},
+        }
+      }
+    });
+```
+
 
 ## Discovery and auto-migration
 

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -522,6 +522,9 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
       const regexOperator = operatorValue.ignoreCase ? ' ~* ?' : ' ~ ?';
       return new ParameterizedSQL(columnName + regexOperator,
         [operatorValue.source]);
+    case 'contains':
+      return new ParameterizedSQL(columnName + ' @> array[' + operatorValue.map((v) => `'${v}'`) + ']::'
+        + propertyDefinition.postgresql.dataType);
     default:
       // invoke the base implementation of `buildExpression`
       return this.invokeSuper('buildExpression', columnName, operator,

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -73,7 +73,7 @@ describe('postgresql connector', function() {
           dataType: 'varchar[]',
         },
       },
-    });
+    }, {allowExtendedOperators: true});
     created = new Date();
   });
 
@@ -264,15 +264,23 @@ describe('postgresql connector', function() {
   });
 
   it('should support where filter for array type field', async () => {
-    Post.dataSource.settings.allowExtendedOperators = true;
-    const post = await Post.find({where: {and: [
+    await Post.create({
+      title: 'LoopBack Participates in Hacktoberfest',
+      categories: ['LoopBack', 'Announcements'],
+    });
+    await Post.create({
+      title: 'Growing LoopBack Community',
+      categories: ['LoopBack', 'Community'],
+    });
+
+    const found = await Post.find({where: {and: [
       {
-        categories: {'contains': ['AA']},
+        categories: {'contains': ['LoopBack', 'Community']},
       },
     ]}});
-    should.exist(post);
-    post.length.should.equal(1);
+    found.map(p => p.title).should.deepEqual(['Growing LoopBack Community']);
   });
+
   it('should support boolean types with false value', function(done) {
     Post.create(
       {title: 'T2', content: 'C2', approved: false, created: created},

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -263,6 +263,16 @@ describe('postgresql connector', function() {
       });
   });
 
+  it('should support where filter for array type field', async () => {
+    Post.dataSource.settings.allowExtendedOperators = true;
+    const post = await Post.find({where: {and: [
+      {
+        categories: {'contains': ['AA']},
+      },
+    ]}});
+    should.exist(post);
+    post.length.should.equal(1);
+  });
   it('should support boolean types with false value', function(done) {
     Post.create(
       {title: 'T2', content: 'C2', approved: false, created: created},

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -218,7 +218,7 @@ describe('postgresql connector', function() {
         post.should.have.property('tags');
         post.tags.should.be.Array();
         post.tags.length.should.eql(2);
-        post.tags.should.eql(['AA', 'AB']);
+        post.tags.toArray().should.eql(['AA', 'AB']);
         return Post.updateAll({where: {id: postId}}, {tags: ['AA', 'AC']});
       })
       .then(()=> {
@@ -228,7 +228,7 @@ describe('postgresql connector', function() {
         post.should.have.property('tags');
         post.tags.should.be.Array();
         post.tags.length.should.eql(2);
-        post.tags.should.eql(['AA', 'AC']);
+        post.tags.toArray().should.eql(['AA', 'AC']);
         done();
       })
       .catch((error) => {
@@ -245,7 +245,7 @@ describe('postgresql connector', function() {
         post.should.have.property('categories');
         post.categories.should.be.Array();
         post.categories.length.should.eql(2);
-        post.categories.should.eql(['AA', 'AB']);
+        post.categories.toArray().should.eql(['AA', 'AB']);
         return Post.updateAll({where: {id: postId}}, {categories: ['AA', 'AC']});
       })
       .then(()=> {
@@ -255,7 +255,7 @@ describe('postgresql connector', function() {
         post.should.have.property('categories');
         post.categories.should.be.Array();
         post.categories.length.should.eql(2);
-        post.categories.should.eql(['AA', 'AC']);
+        post.categories.toArray().should.eql(['AA', 'AC']);
         done();
       })
       .catch((error) => {


### PR DESCRIPTION
- Adds new filter named as contains.
- This filter will search on Array type fields in Postgres DB.


Include references to all related GitHub issues and other pull requests, for example:

Fixes #342 

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
