### PR TITLE
fix: enable pool error handling

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -54,7 +54,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
  *
  * @param {PostgreSQL} postgresql PostgreSQL node.js binding
  * @options {Object} settings An object for the data source settings.
- * See [node-postgres documentation](https://github.com/brianc/node-postgres/wiki/Client#parameters).
+ * See [node-postgres documentation](https://node-postgres.com/api/client).
  * @property {String} url URL to the database, such as 'postgres://test:mypassword@localhost:5432/devdb'.
  * Other parameters can be defined as query string of the url
  * @property {String} hostname The host name or ip address of the PostgreSQL DB server
@@ -63,6 +63,8 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
  * @property {String} password The password
  * @property {String} database The database name
  * @property {Boolean} ssl Whether to try SSL/TLS to connect to server
+ * @property {Function | string} [onError] Optional hook to connect to the pg pool 'error' event,
+ * or the string 'ignore' to record them with `debug` and otherwise ignore them.
  *
  * @constructor
  */
@@ -78,6 +80,16 @@ function PostgreSQL(postgresql, settings) {
   }
   this.clientConfig.Promise = Promise;
   this.pg = new postgresql.Pool(this.clientConfig);
+
+  if (settings.onError) {
+    if (settings.onError === 'ignore') {
+      this.pg.on('error', function(err) {
+        debug(err);
+      });
+    } else {
+      this.pg.on('error', settings.onError);
+    }
+  }
 
   this.settings = settings;
   debug('Settings %j', settings);


### PR DESCRIPTION
As documented in https://node-postgres.com/api/pool#events, it is _very_ important to attach a listener to the Pg Pool `error` event if you don't want your app to randomly crash/exit if something happens to idle connections in the pool (e.g. someone restarts your PostgreSQL server/pgBouncer/etc., or server times out your idle connection). Currently `loopback-connector-postgresql` provides no means of doing this, which makes writing stable apps that use it hard.

This PR adds an optional `onError` property to the connector settings, which can be one of:
* The string `ignore` to report any errors via `debug`, and otherwise ignore them
* An app-provided listener function to connect to the pool

It also, as a side item, fixes a broken link to the node-postgres documentation.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)

*Testing notes:* The tests here verify it wires up the error handler the way it is documented to work. Still WIP on verifying this in a real app to ensure it really addresses the stability issues.